### PR TITLE
security: harden protected-files workflow (trusted base)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,3 +3,5 @@
 /impact-tools/ssh-recovery.sh         @office-hue/maintainers
 /wp-content/mu-plugins/impact-safety-suite.php  @office-hue/maintainers
 /.deploy.production.env               @office-hue/maintainers
+
+.github/protected-files.txt @office-hue/maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+/bin/impactctl                        @office-hue/maintainers
+/impact-tools/access-guard.sh         @office-hue/maintainers
+/impact-tools/ssh-recovery.sh         @office-hue/maintainers
+/wp-content/mu-plugins/impact-safety-suite.php  @office-hue/maintainers
+/.deploy.production.env               @office-hue/maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,3 +5,4 @@
 /.deploy.production.env               @office-hue/maintainers
 
 .github/protected-files.txt @office-hue/maintainers
+.github/workflows/protect-critical-files.yml @office-hue/maintainers

--- a/.github/protected-files.txt
+++ b/.github/protected-files.txt
@@ -1,0 +1,15 @@
+# Critical scripts and deploy tools
+bin/impactctl
+impact-tools/**
+bin/deploy*.sh
+bin/staging-qa-suite.sh
+bin/error-reporter.sh
+
+# MU plugins & production env
+wp-content/mu-plugins/**
+.deploy.production.env
+.deploy.staging.env
+
+# Security workflows and lists
+.github/workflows/protect-critical-files.yml
+.github/protected-files.txt

--- a/.github/workflows/protect-critical-files.yml
+++ b/.github/workflows/protect-critical-files.yml
@@ -1,57 +1,107 @@
-name: protect-critical-files
+name: Protect critical files
 
 on:
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
-  check:
-    name: protect-critical-files / check
+  guard:
+    name: Guard protected files (tamper-proof)
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
     steps:
-      # Fontos: a PR HEAD commitját ellenőrizzük, de a workflow maga a base-ről fut
-      - name: Checkout PR head (read-only)
+      - name: Checkout base (trusted)
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.base_ref }}
           fetch-depth: 0
 
-      - name: Fail on protected file changes
+      - name: Fetch PR head (untrusted) without checkout
+        run: |
+          git fetch origin "+refs/pull/${{ github.event.pull_request.number }}/head:pr_head"
+
+      - name: Read protected list from trusted base
+        id: protected
         shell: bash
         run: |
           set -euo pipefail
+          BASE_REF="${{ github.base_ref }}"
+          LIST_PATH=".github/protected-files.txt"
 
-          BASE="${{ github.base_ref || github.event.pull_request.base.ref }}"
-          git fetch origin "$BASE"
-
-          # 1) Tiltás: a lista PR-ben nem módosítható
-          CHANGED="$(git diff --name-only "origin/${BASE}...HEAD")"
-          if printf '%s\n' "$CHANGED" | grep -qx ".github/protected-files.txt"; then
-            echo "❌ PR modifies .github/protected-files.txt (forbidden)"; exit 1
+          if ! git show "origin/${BASE_REF}:${LIST_PATH}" > /tmp/protected-files.txt 2>/dev/null; then
+            echo "❌ Missing ${LIST_PATH} on base branch (${BASE_REF})." >&2
+            exit 1
           fi
 
-          # 2) A védett lista mindig a base ágról jön (PR nem írhatja felül)
-          if ! PROTECTED_FILES="$(git show "origin/${BASE}:.github/protected-files.txt" 2>/dev/null)"; then
-            echo "❌ Error: cannot read .github/protected-files.txt from base branch (${BASE})"; exit 2
+          # Szűrés: üres sorok és # kommentek eldobása
+          grep -v -E '^\s*#' /tmp/protected-files.txt | sed '/^\s*$/d' > /tmp/protected-files.clean
+          if [[ ! -s /tmp/protected-files.clean ]]; then
+            echo "❌ ${LIST_PATH} is empty on base branch. Failing closed." >&2
+            exit 1
           fi
-          if [ -z "$PROTECTED_FILES" ]; then
-            echo "❌ Error: .github/protected-files.txt on base is empty"; exit 2
-          fi
 
-          echo "ℹ️ Changed files:"; printf '%s\n' "$CHANGED" | sed '/^$/d' || true
+          echo "Protected patterns (from base):"
+          cat /tmp/protected-files.clean
 
-          # 3) Ellenőrzés: módosult-e bármely védett útvonal (pontos egyezés)
-          while IFS= read -r FILE; do
-            # üres sorok / kommentek kihagyása
-            [ -n "${FILE// }" ] || continue
-            case "$FILE" in \#*) continue;; esac
+      - name: Compute changed files in PR head
+        id: changes
+        shell: bash
+        run: |
+          set -euo pipefail
+          git checkout pr_head
+          # Listázd a BASE..HEAD diffben érintett fájlokat (A/M/D/R)
+          git diff --name-only --diff-filter=ACDMR "origin/${{ github.base_ref }}" pr_head > /tmp/changed.txt || true
+          echo "Changed files:"
+          cat /tmp/changed.txt || true
 
-            if printf '%s\n' "$CHANGED" | grep -qx -- "$FILE"; then
-              echo "❌ PR modifies a protected file: $FILE"; exit 1
+      - name: Match changes against protected patterns
+        id: match
+        shell: bash
+        run: |
+          set -euo pipefail
+          touch /tmp/violations.txt
+          while IFS= read -r pat; do
+            while IFS= read -r f; do
+              python3 - <<'PY' "$pat" "$f" >> /tmp/violations.txt
+import fnmatch, sys
+pat = sys.argv[1].strip()
+fn = sys.argv[2].strip()
+if fnmatch.fnmatch(fn, pat):
+    print(fn)
+PY
+            done < /tmp/changed.txt
+          done < /tmp/protected-files.clean
+
+          # Tiltás: a lista önmódosítása is védett
+          if grep -Fx ".github/protected-files.txt" /tmp/protected-files.clean >/dev/null 2>&1; then
+            if grep -Fx ".github/protected-files.txt" /tmp/changed.txt >/dev/null 2>&1; then
+              echo ".github/protected-files.txt" >> /tmp/violations.txt
             fi
-          done <<<"$PROTECTED_FILES"
+          fi
 
-          echo "✅ Protected files untouched"
+          sort -u /tmp/violations.txt -o /tmp/violations.txt
+          echo "violations<<EOF" >> "$GITHUB_OUTPUT"
+          cat /tmp/violations.txt >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+          echo "Recorded protected matches:"
+          cat /tmp/violations.txt || true
+
+      - name: Fail if protected files were modified
+        if: ${{ steps.match.outputs.violations != '' }}
+        shell: bash
+        run: |
+          echo "❌ PR modifies protected files:" >&2
+          cat <<'LIST' >&2
+${{ steps.match.outputs.violations }}
+LIST
+          echo ""
+          echo "This repository uses a tamper-proof protection: the list is loaded from the trusted base branch and cannot be modified by PRs." >&2
+          exit 1
+
+      - name: Pass (no protected files were touched)
+        if: ${{ steps.match.outputs.violations == '' }}
+        run: echo "✅ No protected files modified."

--- a/.github/workflows/protect-critical-files.yml
+++ b/.github/workflows/protect-critical-files.yml
@@ -1,26 +1,57 @@
 name: protect-critical-files
+
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
+
 jobs:
   check:
-    name: check
+    name: protect-critical-files / check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
-      - uses: actions/checkout@v4
+      # Fontos: a PR HEAD commitját ellenőrizzük, de a workflow maga a base-ről fut
+      - name: Checkout PR head (read-only)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
       - name: Fail on protected file changes
         shell: bash
         run: |
           set -euo pipefail
-          PROTECTED_FILES=$'# List (one per line)\nbin/impactctl\nimpact-tools/access-guard.sh\nimpact-tools/ssh-recovery.sh\nwp-content/mu-plugins/impact-safety-suite.php\n.deploy.production.env\n'
+
           BASE="${{ github.base_ref || github.event.pull_request.base.ref }}"
-          git fetch origin "$BASE" >/dev/null 2>&1 || true
-          CHANGED="$(git diff --name-only "origin/${BASE}...HEAD" || true)"
-          echo "ℹ️ Changed files:"; printf '%s\n' "$CHANGED"
+          git fetch origin "$BASE"
+
+          # 1) Tiltás: a lista PR-ben nem módosítható
+          CHANGED="$(git diff --name-only "origin/${BASE}...HEAD")"
+          if printf '%s\n' "$CHANGED" | grep -qx ".github/protected-files.txt"; then
+            echo "❌ PR modifies .github/protected-files.txt (forbidden)"; exit 1
+          fi
+
+          # 2) A védett lista mindig a base ágról jön (PR nem írhatja felül)
+          if ! PROTECTED_FILES="$(git show "origin/${BASE}:.github/protected-files.txt" 2>/dev/null)"; then
+            echo "❌ Error: cannot read .github/protected-files.txt from base branch (${BASE})"; exit 2
+          fi
+          if [ -z "$PROTECTED_FILES" ]; then
+            echo "❌ Error: .github/protected-files.txt on base is empty"; exit 2
+          fi
+
+          echo "ℹ️ Changed files:"; printf '%s\n' "$CHANGED" | sed '/^$/d' || true
+
+          # 3) Ellenőrzés: módosult-e bármely védett útvonal (pontos egyezés)
           while IFS= read -r FILE; do
-            [ -n "$FILE" ] || continue
+            # üres sorok / kommentek kihagyása
+            [ -n "${FILE// }" ] || continue
+            case "$FILE" in \#*) continue;; esac
+
             if printf '%s\n' "$CHANGED" | grep -qx -- "$FILE"; then
-              echo "❌ PR módosít védett fájlt: $FILE"; exit 1
+              echo "❌ PR modifies a protected file: $FILE"; exit 1
             fi
-          done <<<"$(printf '%s' "$PROTECTED_FILES")"
-          echo "✅ védett fájlok érintetlenek"
+          done <<<"$PROTECTED_FILES"
+
+          echo "✅ Protected files untouched"

--- a/.github/workflows/protect-critical-files.yml
+++ b/.github/workflows/protect-critical-files.yml
@@ -1,0 +1,26 @@
+name: protect-critical-files
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+jobs:
+  check:
+    name: check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Fail on protected file changes
+        shell: bash
+        run: |
+          set -euo pipefail
+          PROTECTED_FILES=$'# List (one per line)\nbin/impactctl\nimpact-tools/access-guard.sh\nimpact-tools/ssh-recovery.sh\nwp-content/mu-plugins/impact-safety-suite.php\n.deploy.production.env\n'
+          BASE="${{ github.base_ref || github.event.pull_request.base.ref }}"
+          git fetch origin "$BASE" >/dev/null 2>&1 || true
+          CHANGED="$(git diff --name-only "origin/${BASE}...HEAD" || true)"
+          echo "ℹ️ Changed files:"; printf '%s\n' "$CHANGED"
+          while IFS= read -r FILE; do
+            [ -n "$FILE" ] || continue
+            if printf '%s\n' "$CHANGED" | grep -qx -- "$FILE"; then
+              echo "❌ PR módosít védett fájlt: $FILE"; exit 1
+            fi
+          done <<<"$(printf '%s' "$PROTECTED_FILES")"
+          echo "✅ védett fájlok érintetlenek"

--- a/docs/SECURITY_PROTECTION.md
+++ b/docs/SECURITY_PROTECTION.md
@@ -1,0 +1,16 @@
+# Protect Critical Files — Tamper-Proof PR Guard
+
+This repository blocks pull requests that modify files listed in `.github/protected-files.txt`.
+The workflow runs with `pull_request_target` on the trusted base branch and loads the protection
+list from the base. Missing or empty list -> fail-closed.
+
+## Smoke test
+```bash
+git checkout main && git pull
+git checkout -b test/protection-smoke-test
+echo "# test" >> bin/impactctl
+git add bin/impactctl
+git commit -m "test: attempt to modify protected file"
+git push -u origin test/protection-smoke-test
+# Open PR → CI should fail with a list of protected files touched.
+```


### PR DESCRIPTION
Run from pull_request_target; read protected list from base; forbid list change; no silent failures.