### PR TITLE
CI: add read-only Validation Gate workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive   # fontos a nested repo-k miatt
+
+      # (Opciós) SSH kulcs beállítás, ha a runnernek kell közvetlenül SSH-zni
+      # - name: Setup SSH key (optional)
+      #   if: ${{ secrets.STAGING_SSH_KEY != '' }}
+      #   run: |
+      #     mkdir -p ~/.ssh
+      #     echo "${{ secrets.STAGING_SSH_KEY }}" > ~/.ssh/id_ed25519
+      #     chmod 600 ~/.ssh/id_ed25519
+      #     ssh-keyscan "${{ secrets.STAGING_SSH_HOST }}" >> ~/.ssh/known_hosts
+
+      - name: Validation Gate (read-only)
+        run: |
+          bash scripts/validate-deploy-profile.sh \
+            --profile=staging \
+            --timeout-ssh=10 \
+            --timeout-wpcli=30
+        env:
+          SSH_HOST: ${{ secrets.STAGING_SSH_HOST }}
+          SSH_USER: ${{ secrets.STAGING_SSH_USER }}
+          WP_PATH:  ${{ secrets.STAGING_WP_PATH }}

--- a/execution_run.sh
+++ b/execution_run.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NOW=$(date -u +%Y%m%dT%H%M%SZ)
+RUN_DIR=".codex/reports/execution/run_${NOW}"
+LOG_DIR="${RUN_DIR}/logs"
+SUMMARY="${RUN_DIR}/execution_run_summary.md"
+mkdir -p "$LOG_DIR"
+
+{
+  echo "# Execution-RUN ${NOW}"
+  echo "Flags:"
+  echo "  RUN_GIT_ROOT=${RUN_GIT_ROOT:-0}"
+  echo "  RUN_VALIDATION=${RUN_VALIDATION:-0}"
+  echo "  RUN_CI_MIGRATION=${RUN_CI_MIGRATION:-0}"
+  echo "  RUN_DASHBOARD_CRON=${RUN_DASHBOARD_CRON:-0}"
+} > "$SUMMARY"
+
+PACK2_LOG="${LOG_DIR}/validation_gate_pilot.log"
+PACK3_LOG="${LOG_DIR}/ci_migration_run.log"
+
+if [[ "${RUN_VALIDATION:-0}" = "1" ]]; then
+  {
+    echo "=== Pack #2 - Validation Gate (REAL RUN) ==="
+    echo "Host: ${SSH_HOST:-<unset>}"
+    echo "User: ${SSH_USER:-<unset>}"
+    echo "WP_PATH: ${WP_PATH:-<unset>}"
+    echo "Command:"
+    echo "  bash scripts/validate-deploy-profile.sh --profile=staging --timeout-ssh=10 --timeout-wpcli=30"
+    bash scripts/validate-deploy-profile.sh --profile=staging --timeout-ssh=10 --timeout-wpcli=30 || true
+  } &> "$PACK2_LOG"
+else
+  {
+    echo "=== Pack #2 - Validation Gate (DRY-RUN) ==="
+    echo "Would run:"
+    echo "  bash scripts/validate-deploy-profile.sh --profile=staging --timeout-ssh=10 --timeout-wpcli=30"
+    echo "No remote calls made."
+    echo "Exit: DRY-RUN"
+  } > "$PACK2_LOG"
+fi
+
+if [[ "${RUN_VALIDATION:-0}" = "1" ]]; then
+  if grep -qE "Exit:\\s*0|✅" "$PACK2_LOG"; then
+    echo "- Pack #2: PASS" >> "$SUMMARY"
+    mkdir -p .codex/reports/execution
+    date -u +%Y-%m-%dT%H:%M:%SZ > .codex/reports/execution/validation_signedoff.flag
+  elif grep -qiE "fail|❌|exit:\\s*1|exit:\\s*2" "$PACK2_LOG"; then
+    echo "- Pack #2: HOLD (see $PACK2_LOG)" >> "$SUMMARY"
+  else
+    echo "- Pack #2: REVIEW (see $PACK2_LOG)" >> "$SUMMARY"
+  fi
+else
+  echo "- Pack #2: DRY-RUN (see $PACK2_LOG)" >> "$SUMMARY"
+fi
+
+echo "- Pack #2 logs: $PACK2_LOG" >> "$SUMMARY"
+
+if [[ "${RUN_CI_MIGRATION:-0}" = "1" ]]; then
+  {
+    echo "=== Pack #3 - CI Migration ==="
+    if [[ -f .github/workflows/ci.yml ]]; then
+      echo "[OK] Workflow present: .github/workflows/ci.yml"
+    else
+      echo "[MISS] Workflow missing: .github/workflows/ci.yml"
+    fi
+
+    CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo main)"
+    echo "[INFO] Current branch: ${CURRENT_BRANCH}"
+
+    if command -v gh >/dev/null 2>&1; then
+      echo "[INFO] gh version: $(gh --version | head -1)"
+      echo "[INFO] gh auth status:"
+      gh auth status || true
+
+      echo "[INFO] Triggering workflow dispatch via gh workflow run"
+      gh workflow run ci.yml --ref="${CI_REF:-${CURRENT_BRANCH}}" || echo "[WARN] gh workflow run failed or workflow disabled"
+
+      echo "[INFO] Listing latest workflow runs"
+      gh run list --limit 5 --json databaseId,status,conclusion,workflowName,displayTitle,headBranch,createdAt 2>/dev/null || echo "[WARN] gh run list unavailable"
+    else
+      echo "[WARN] gh CLI not available; relying on push-triggered workflow."
+    fi
+  } &> "$PACK3_LOG"
+else
+  {
+    echo "=== Pack #3 - CI Migration (DRY-RUN) ==="
+    echo "Would ensure .github/workflows/ci.yml present and trigger workflow dispatch."
+    echo "No workflow run triggered."
+  } > "$PACK3_LOG"
+fi
+
+if [[ "${RUN_CI_MIGRATION:-0}" = "1" ]]; then
+  if grep -qiE "success|pass" "$PACK3_LOG"; then
+    echo "- Pack #3: PASS" >> "$SUMMARY"
+    mkdir -p .codex/reports/execution
+    date -u +%Y-%m-%dT%H:%M:%SZ > .codex/reports/execution/ci_migration_completed.flag
+  elif grep -qiE "queued|triggered" "$PACK3_LOG"; then
+    echo "- Pack #3: TRIGGERED (waiting) – see $PACK3_LOG" >> "$SUMMARY"
+  else
+    echo "- Pack #3: HOLD (see $PACK3_LOG)" >> "$SUMMARY"
+  fi
+else
+  echo "- Pack #3: DRY-RUN (see $PACK3_LOG)" >> "$SUMMARY"
+fi
+
+echo "- Pack #3 logs: $PACK3_LOG" >> "$SUMMARY"
+
+echo "$RUN_DIR"

--- a/scripts/validate-deploy-profile.sh
+++ b/scripts/validate-deploy-profile.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROFILE="staging"
+TIMEOUT_SSH=10
+TIMEOUT_WPCLI=30
+
+# timeout bin discovery (supports macOS coreutils `gtimeout`)
+TIMEOUT_BIN=""
+if command -v timeout >/dev/null 2>&1; then
+  TIMEOUT_BIN="timeout"
+elif command -v gtimeout >/dev/null 2>&1; then
+  TIMEOUT_BIN="gtimeout"
+fi
+
+run_with_timeout() {
+  local seconds="$1"
+  shift
+  if [[ -n "$TIMEOUT_BIN" ]]; then
+    "$TIMEOUT_BIN" "$seconds" "$@"
+  else
+    "$@"
+  fi
+}
+
+# Opcionális argok
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --profile=*) PROFILE="${1#*=}"; shift ;;
+    --timeout-ssh=*) TIMEOUT_SSH="${1#*=}"; shift ;;
+    --timeout-wpcli=*) TIMEOUT_WPCLI="${1#*=}"; shift ;;
+    *) shift ;;
+  esac
+done
+
+# Kötelező env változók
+REQUIRED=(SSH_HOST SSH_USER WP_PATH)
+MISSING=()
+for k in "${REQUIRED[@]}"; do
+  v="$(printenv "$k" || true)"
+  [[ -z "${v:-}" ]] && MISSING+=("$k")
+done
+
+echo "=== Deploy Profile Validation ==="
+echo "Profile: $PROFILE"
+echo "SSH timeout: ${TIMEOUT_SSH}s"
+echo "WP-CLI timeout: ${TIMEOUT_WPCLI}s"
+
+if [[ ${#MISSING[@]} -gt 0 ]]; then
+  echo "Missing fields: ${MISSING[*]}"
+  echo "Exit: 2"
+  exit 2
+fi
+
+# SSH reachability (read-only) — locale zaj elkerülésére LANG=C
+if ! run_with_timeout "${TIMEOUT_SSH}" ssh -o BatchMode=yes -o ConnectTimeout="${TIMEOUT_SSH}" \
+  "${SSH_USER}@${SSH_HOST}" 'LANG=C LC_ALL=C echo connected' >/dev/null 2>&1; then
+  echo "❌ SSH reachability: FAIL"
+  echo "Exit: 1"
+  exit 1
+else
+  echo "✅ SSH reachability: PASS"
+fi
+
+# WP-CLI availability (read-only) — szintén LANG=C
+if run_with_timeout "${TIMEOUT_WPCLI}" ssh -o BatchMode=yes "${SSH_USER}@${SSH_HOST}" \
+  "LANG=C LC_ALL=C command -v wp >/dev/null && wp --path='${WP_PATH}' --version" >/dev/null 2>&1; then
+  echo "✅ WP-CLI availability: PASS"
+  echo "Exit: 0"
+  exit 0
+else
+  echo "⚠️ WP-CLI availability: FAIL"
+  echo "Exit: 2"
+  exit 2
+fi


### PR DESCRIPTION
Adds GitHub Actions workflow (.github/workflows/ci.yml) reusing the read-only Validation Gate.

Changes:
- Workflow: .github/workflows/ci.yml (checkout submodules, read-only validation)
- Script: scripts/validate-deploy-profile.sh (timeout/gtimeout autodetect, macOS/Linux)
- Runner-safe: no secrets in repo; all via GitHub Secrets
- Execution framework: execution_run.sh logs Pack #3 + creates completion flag

Gates:
- Pack #1 PASS: git_root_completed.flag
- Pack #2 PASS: validation_signedoff.flag

Status:
- Previously HOLD due to workflow not on default branch; merge to main registers workflow.