### PR TITLE
T-103: PR template szigorítás (risk + evidence + rollback)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,34 @@
+## Summary
+- What changed?
+- Why was it needed?
+
+## Scope Boundaries
+- In scope:
+- Explicitly out of scope:
+
+## Risk Level
+- [ ] Low
+- [ ] Medium
+- [ ] High
+- Risk notes:
+
+## Test Evidence
+- Commands run:
+- Result summary:
+
+## Guard Evidence
+- [ ] Safe audit strict passed (`scripts/safe-repo-audit.sh --repo <repo> --strict`)
+- [ ] Impactall considered (when relevant)
+- Additional guard notes:
+
+## Rollback Plan
+- Revert strategy:
+- Data/ops impact during rollback:
+
+## Docs
+- [ ] Docs updated
+- [ ] Docs not needed (reason):
+
+## Docs-only Exception
+- [ ] This is docs-only (no runtime/code path changes)
+- If checked: list touched paths and why tests/guards were minimized.


### PR DESCRIPTION
Closing — a `.github/pull_request_template.md` már létezik main-en egy bővebb, frissebb verzióban (PR exit checklist + guard evidence szekciókkal). Ez a branch elavult/superseded.