### PR TITLE
ops-policy: one-path workflow enforcement

### DIFF
--- a/docs/pr-policy.md
+++ b/docs/pr-policy.md
@@ -1,20 +1,38 @@
-# PR Policy (Standard)
+# PR Policy (Enforced One-Path)
 
-Ez a repo a közös PR és hook policyt követi.
+Ez a repo **kötelező, egyetlen útvonalú** commit/push/PR/deploy policyt követ.
 
-## Kötelező PR szabályok
+## Kötelező útvonal (minden munka)
 
-- Új fejlesztői ág indítása mindig `origin/main` alapról történjen.
-- Kötelező PR template használat checkboxokkal.
-- A `PR-EXIT-CHECKLIST.md` pontjai legyenek maradéktalanul kipipálva.
-- Push előtt a `pre-push` hook kötelezően fusson `--strict --mode push` módban.
+1. Új klón vagy új worktree után futtasd:
+   - `bash scripts/install-hooks-all.sh`
+2. Új fejlesztés csak `origin/main` alapról indulhat:
+   - `bash scripts/start-feature-worktree.sh <feature-branch>`
+3. Módosítás után kötelező helyi állapotellenőrzés:
+   - `bash scripts/git-health-check.sh`
+4. Push csak feature/worktree ágról mehet, `main/master` közvetlen push tiltott.
+5. PR csak kötelező checklist blokkal nyitható (`PR-EXIT-CHECKLIST.md`).
+6. Deploy csak guardolt útvonalon mehet, és csak merge-elt főágból.
 
-## Ajánlott napi/heti rutin
+## Hard enforce (technikailag beállítva)
 
-- Új klón vagy új worktree után futtasd: `bash scripts/install-hooks.sh`
-- Új munkaág indítása: `bash scripts/start-feature-worktree.sh <feature-branch>`
-- Állapotellenőrzés: `bash scripts/git-health-check.sh`
+- `pre-commit` hook: blokkolja a commitot `main/master` ágon.
+- `pre-push` hook: blokkolja a közvetlen `main/master` push-t.
+- `pre-push` hook: kötelező policy fájlok meglétét ellenőrzi.
+- `pre-push` hook: `safe-repo-audit.sh --strict --mode push` futtatása kötelező.
+- CI: PR Checklist Guard kötelező PR body ellenőrzéssel.
 
-## Cél
+## Kötelező policy fájlok
 
-A policy célja, hogy csökkentse a hamis blokkolást, és egységes, auditálható PR/deploy folyamatot adjon mindhárom aktív repóban.
+- `docs/pr-policy.md`
+- `PR-EXIT-CHECKLIST.md`
+- `.github/pull_request_template.md`
+- `scripts/start-feature-worktree.sh`
+- `scripts/git-health-check.sh`
+
+## Vészhelyzeti bypass (csak jóváhagyással)
+
+- commit bypass: `IMPACT_POLICY_ALLOW_MAIN_COMMIT=1`
+- push bypass: `IMPACT_POLICY_ALLOW_MAIN_PUSH=1`
+
+A bypass használata csak ideiglenesen engedett, és PR-ben kötelező dokumentálni.

--- a/notes.md
+++ b/notes.md
@@ -3375,3 +3375,9 @@ Saved 43 promotions to /Users/bujdosoarnold/Documents/GitHub/ai-agent/tools/out/
 - Strict audit (clean worktree, impactshop-notes): `scripts/safe-repo-audit.sh --repo /Users/bujdosoarnold/Developer/GitHub/.worktrees/impactshop-notes-checkpoint-2026-03-05 --strict` -> PASS (`no local changes`).
 - Strict audit (clean worktree, impact_hub): `scripts/safe-repo-audit.sh --repo /private/tmp/impact_hub-checkpoint-20260305 --strict` -> PASS (`no local changes`).
 - Queue cleanup: `office-hue/ai-agent` PR #8 lezárva.
+
+### 2026-03-08 – One-path policy enforce (ops)
+- Kötelező útvonal rögzítve: `install-hooks-all.sh` -> `start-feature-worktree.sh` -> `git-health-check.sh` -> PR checklist -> merge.
+- Hook policy egységes: `pre-commit` main/master tiltás + `pre-push` direct main push tiltás.
+- Pre-push audit standard: `safe-repo-audit.sh --strict --mode push`.
+- PR kötelező checklist blokk + CI guard aktív; hiány esetén merge tiltás.

--- a/scripts/git-health-check.sh
+++ b/scripts/git-health-check.sh
@@ -15,6 +15,12 @@ FAIL_COUNT=0
 echo "[git-health-check] repo: $REPO_NAME"
 echo "[git-health-check] branch: $(git branch --show-current 2>/dev/null || echo detached)"
 
+BRANCH="$(git branch --show-current 2>/dev/null || echo detached)"
+if [[ "$BRANCH" == "main" || "$BRANCH" == "master" ]]; then
+  echo "[git-health-check] FAIL: main/master ágon vagy. Commit/push csak feature/worktree ágon mehet."
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+fi
+
 if git show-ref --verify --quiet refs/heads/main && git show-ref --verify --quiet refs/remotes/origin/main; then
   counts="$(git rev-list --left-right --count main...origin/main)"
   ahead="${counts%%$'\t'*}"
@@ -38,24 +44,72 @@ else
   echo "[git-health-check] OK: nincs [gone] ág"
 fi
 
-HOOK_PATH="$(git rev-parse --git-path hooks/pre-push)"
-if [[ -x "$HOOK_PATH" ]]; then
-  if rg -q -- '--strict --mode push' "$HOOK_PATH"; then
-    echo "[git-health-check] OK: pre-push policy --strict --mode push"
+required_paths=(
+  "scripts/start-feature-worktree.sh"
+  "scripts/git-health-check.sh"
+  "docs/pr-policy.md"
+  ".github/pull_request_template.md"
+  "PR-EXIT-CHECKLIST.md"
+)
+
+for rel in "${required_paths[@]}"; do
+  if [[ ! -e "$REPO_ROOT/$rel" ]]; then
+    echo "[git-health-check] FAIL: hiányzó kötelező policy fájl: $rel"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+done
+
+PRE_COMMIT_HOOK="$(git rev-parse --git-path hooks/pre-commit)"
+if [[ -x "$PRE_COMMIT_HOOK" ]]; then
+  if rg -q -- 'IMPACT_POLICY_ALLOW_MAIN_COMMIT' "$PRE_COMMIT_HOOK"; then
+    echo "[git-health-check] OK: pre-commit main-branch gate aktív"
+  else
+    echo "[git-health-check] FAIL: pre-commit hookból hiányzik a main branch gate"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+else
+  echo "[git-health-check] FAIL: hiányzó vagy nem futtatható pre-commit hook: $PRE_COMMIT_HOOK"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+fi
+
+PRE_PUSH_HOOK="$(git rev-parse --git-path hooks/pre-push)"
+if [[ -x "$PRE_PUSH_HOOK" ]]; then
+  if rg -q -- '--strict --mode push' "$PRE_PUSH_HOOK"; then
+    echo "[git-health-check] OK: pre-push strict audit aktív"
   else
     echo "[git-health-check] FAIL: pre-push hookból hiányzik a --strict --mode push"
     FAIL_COUNT=$((FAIL_COUNT + 1))
   fi
+
+  if rg -q -- 'IMPACT_POLICY_ALLOW_MAIN_PUSH' "$PRE_PUSH_HOOK"; then
+    echo "[git-health-check] OK: pre-push main-branch gate aktív"
+  else
+    echo "[git-health-check] FAIL: pre-push hookból hiányzik a main push gate"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
 else
-  echo "[git-health-check] FAIL: hiányzó vagy nem futtatható pre-push hook: $HOOK_PATH"
+  echo "[git-health-check] FAIL: hiányzó vagy nem futtatható pre-push hook: $PRE_PUSH_HOOK"
   FAIL_COUNT=$((FAIL_COUNT + 1))
 fi
 
-if [[ ! -x "$REPO_ROOT/scripts/safe-repo-audit.sh" ]]; then
-  echo "[git-health-check] FAIL: hiányzó scripts/safe-repo-audit.sh"
+SAFE_AUDIT_SCRIPT=""
+search_dir="$REPO_ROOT"
+for _ in 1 2 3 4 5 6; do
+  candidate="$search_dir/scripts/safe-repo-audit.sh"
+  if [[ -x "$candidate" ]]; then
+    SAFE_AUDIT_SCRIPT="$candidate"
+    break
+  fi
+  parent="$(cd "$search_dir/.." && pwd)"
+  [[ "$parent" == "$search_dir" ]] && break
+  search_dir="$parent"
+done
+
+if [[ -z "$SAFE_AUDIT_SCRIPT" ]]; then
+  echo "[git-health-check] FAIL: nem található futtatható safe-repo-audit.sh"
   FAIL_COUNT=$((FAIL_COUNT + 1))
 else
-  echo "[git-health-check] OK: scripts/safe-repo-audit.sh elérhető"
+  echo "[git-health-check] OK: safe-repo-audit elérhető: $SAFE_AUDIT_SCRIPT"
 fi
 
 echo "[git-health-check] summary: WARN=$WARN_COUNT FAIL=$FAIL_COUNT"

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [[ -z "${REPO_ROOT}" ]]; then
+  echo "[install-hooks] hiba: nem git repóban futsz." >&2
+  exit 1
+fi
+
+ORIGIN_URL="$(git -C "$REPO_ROOT" remote get-url origin 2>/dev/null || true)"
+
+case "$ORIGIN_URL" in
+  *impactshop-notes.git)
+    ORIGIN_ENV_VAR="IMPACTSHOP_NOTES_EXPECTED_ORIGIN"
+    DEFAULT_ORIGIN="https://github.com/office-hue/impactshop-notes.git"
+    ORIGIN_MODE="required"
+    ;;
+  *ai-agent.git)
+    ORIGIN_ENV_VAR="AI_AGENT_EXPECTED_ORIGIN"
+    DEFAULT_ORIGIN=""
+    ORIGIN_MODE="optional"
+    ;;
+  *impact_hub.git)
+    ORIGIN_ENV_VAR="IMPACT_HUB_EXPECTED_ORIGIN"
+    DEFAULT_ORIGIN="https://github.com/office-hue/impact_hub.git"
+    ORIGIN_MODE="required"
+    ;;
+  *)
+    # Fallback by path for local/offline cases.
+    if [[ "$REPO_ROOT" == *"/impactshop-notes"* || "$REPO_ROOT" == *"/impactshop-notes-"* ]]; then
+      ORIGIN_ENV_VAR="IMPACTSHOP_NOTES_EXPECTED_ORIGIN"
+      DEFAULT_ORIGIN="https://github.com/office-hue/impactshop-notes.git"
+      ORIGIN_MODE="required"
+    elif [[ "$REPO_ROOT" == *"/ai-agent"* || "$REPO_ROOT" == *"/ai-agent-"* ]]; then
+      ORIGIN_ENV_VAR="AI_AGENT_EXPECTED_ORIGIN"
+      DEFAULT_ORIGIN=""
+      ORIGIN_MODE="optional"
+    elif [[ "$REPO_ROOT" == *"/impact_hub"* || "$REPO_ROOT" == *"/impact_hub-"* ]]; then
+      ORIGIN_ENV_VAR="IMPACT_HUB_EXPECTED_ORIGIN"
+      DEFAULT_ORIGIN="https://github.com/office-hue/impact_hub.git"
+      ORIGIN_MODE="required"
+    else
+      echo "[install-hooks] hiba: nem támogatott repo (origin/path alapján): $REPO_ROOT" >&2
+      exit 1
+    fi
+    ;;
+esac
+
+HOOK_DIR="$(git -C "$REPO_ROOT" rev-parse --git-path hooks)"
+if [[ "$HOOK_DIR" != /* ]]; then
+  HOOK_DIR="${REPO_ROOT}/${HOOK_DIR}"
+fi
+mkdir -p "${HOOK_DIR}"
+
+cat > "${HOOK_DIR}/pre-commit" <<'HOOK'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${IMPACT_POLICY_ALLOW_MAIN_COMMIT:-0}" == "1" ]]; then
+  exit 0
+fi
+
+BRANCH="$(git branch --show-current 2>/dev/null || echo detached)"
+if [[ "$BRANCH" == "main" || "$BRANCH" == "master" ]]; then
+  echo "[repo-guard] Blocked commit on protected branch: $BRANCH" >&2
+  echo "[repo-guard] Use feature/worktree flow:" >&2
+  echo "[repo-guard]   bash scripts/start-feature-worktree.sh <feature-branch>" >&2
+  echo "[repo-guard] Emergency bypass (approval required): IMPACT_POLICY_ALLOW_MAIN_COMMIT=1" >&2
+  exit 1
+fi
+HOOK
+
+cat > "${HOOK_DIR}/pre-push" <<HOOK
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="\$(git rev-parse --show-toplevel)"
+BRANCH="\$(git branch --show-current 2>/dev/null || echo detached)"
+
+if [[ "\${IMPACT_POLICY_ALLOW_MAIN_PUSH:-0}" != "1" ]]; then
+  if [[ "\$BRANCH" == "main" || "\$BRANCH" == "master" ]]; then
+    echo "[repo-guard] Blocked push from protected branch: \$BRANCH" >&2
+    echo "[repo-guard] Use feature/worktree flow:" >&2
+    echo "[repo-guard]   bash scripts/start-feature-worktree.sh <feature-branch>" >&2
+    echo "[repo-guard] Emergency bypass (approval required): IMPACT_POLICY_ALLOW_MAIN_PUSH=1" >&2
+    exit 1
+  fi
+
+  while read -r local_ref local_sha remote_ref remote_sha; do
+    [[ -z "\${local_ref:-}" ]] && continue
+    if [[ "\$local_ref" == "refs/heads/main" || "\$remote_ref" == "refs/heads/main" || "\$local_ref" == "refs/heads/master" || "\$remote_ref" == "refs/heads/master" ]]; then
+      echo "[repo-guard] Blocked direct push to main/master." >&2
+      echo "[repo-guard] Open PR from feature/worktree branch instead." >&2
+      exit 1
+    fi
+  done
+fi
+
+required_paths=(
+  "scripts/start-feature-worktree.sh"
+  "scripts/git-health-check.sh"
+  "docs/pr-policy.md"
+  ".github/pull_request_template.md"
+  "PR-EXIT-CHECKLIST.md"
+)
+missing=0
+for rel in "\${required_paths[@]}"; do
+  if [[ ! -e "\$REPO_ROOT/\$rel" ]]; then
+    echo "[repo-guard] Missing required policy file: \$rel" >&2
+    missing=1
+  fi
+done
+if [[ "\$missing" -ne 0 ]]; then
+  exit 1
+fi
+
+SAFE_AUDIT_SCRIPT=""
+search_dir="\$REPO_ROOT"
+for _ in 1 2 3 4 5 6; do
+  candidate="\$search_dir/scripts/safe-repo-audit.sh"
+  if [[ -x "\$candidate" ]]; then
+    SAFE_AUDIT_SCRIPT="\$candidate"
+    break
+  fi
+  parent="\$(cd "\$search_dir/.." && pwd)"
+  [[ "\$parent" == "\$search_dir" ]] && break
+  search_dir="\$parent"
+done
+
+if [[ -z "\$SAFE_AUDIT_SCRIPT" ]]; then
+  echo "[repo-guard] missing safe audit script (searched upwards from: \$REPO_ROOT)" >&2
+  exit 1
+fi
+
+"\${SAFE_AUDIT_SCRIPT}" --repo "\${REPO_ROOT}" --strict --mode push
+
+expected_origin="\${${ORIGIN_ENV_VAR}:-${DEFAULT_ORIGIN}}"
+actual_origin="\$(git remote get-url origin 2>/dev/null || true)"
+HOOK
+
+if [[ "$ORIGIN_MODE" == "optional" ]]; then
+  cat >> "${HOOK_DIR}/pre-push" <<'HOOK'
+if [[ -n "${expected_origin}" ]]; then
+  if [[ "${actual_origin}" != "${expected_origin}" ]]; then
+    echo "[repo-guard] Blocked push: origin mismatch" >&2
+    echo "[repo-guard] expected: ${expected_origin}" >&2
+    echo "[repo-guard] actual:   ${actual_origin}" >&2
+    exit 1
+  fi
+else
+  echo "[repo-guard] origin check skipped (expected origin nincs beállítva)"
+fi
+HOOK
+else
+  cat >> "${HOOK_DIR}/pre-push" <<'HOOK'
+if [[ "${actual_origin}" != "${expected_origin}" ]]; then
+  echo "[repo-guard] Blocked push: origin mismatch" >&2
+  echo "[repo-guard] expected: ${expected_origin}" >&2
+  echo "[repo-guard] actual:   ${actual_origin}" >&2
+  exit 1
+fi
+HOOK
+fi
+
+chmod +x "${HOOK_DIR}/pre-commit" "${HOOK_DIR}/pre-push"
+echo "[install-hooks] OK: ${HOOK_DIR}/pre-commit telepítve."
+echo "[install-hooks] OK: ${HOOK_DIR}/pre-push telepítve."
+echo "[install-hooks] enforced one-path policy aktív (commit/push/PR/deploy flow)."

--- a/scripts/safe-repo-audit.sh
+++ b/scripts/safe-repo-audit.sh
@@ -1,0 +1,327 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Safe pre-push audit: read-only checks for potentially sensitive changes.
+# Default behavior: warn only (exit 0). Use --strict to fail on findings.
+
+STRICT=0
+TARGET_PATH="."
+MODE="local"
+PUSH_BASE=""
+PUSH_RANGE=""
+
+usage() {
+  cat <<'EOF'
+Usage:
+  safe-repo-audit.sh [--repo <path>] [--strict] [--mode local|push]
+
+Options:
+  --repo <path>   Target git repository path (default: current directory)
+  --strict        Exit non-zero when warnings are found
+  --mode <mode>   Scan mode: local (working tree) or push (committed range to upstream)
+  -h, --help      Show this help
+
+Examples:
+  ./scripts/safe-repo-audit.sh --repo /Users/.../impact_hub
+  ./scripts/safe-repo-audit.sh --repo /Users/.../impactshop-notes --strict
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      TARGET_PATH="${2:-}"
+      shift 2
+      ;;
+    --strict)
+      STRICT=1
+      shift
+      ;;
+    --mode)
+      MODE="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if ! REPO_ROOT="$(git -C "$TARGET_PATH" rev-parse --show-toplevel 2>/dev/null)"; then
+  echo "ERROR: not a git repository: $TARGET_PATH" >&2
+  exit 1
+fi
+
+if [[ "$MODE" != "local" && "$MODE" != "push" ]]; then
+  echo "ERROR: --mode must be 'local' or 'push' (got: $MODE)" >&2
+  exit 1
+fi
+
+cd "$REPO_ROOT"
+
+BRANCH="$(git branch --show-current 2>/dev/null || echo detached)"
+HEAD_SHA="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+CHANGED_LIST="$TMP_DIR/changed-files.txt"
+FILTERED_CHANGED_LIST="$TMP_DIR/changed-files.filtered.txt"
+ADDED_LINES="$TMP_DIR/added-lines.txt"
+RISKY_NAME_HITS="$TMP_DIR/risky-name-hits.txt"
+ENV_KEY_HITS="$TMP_DIR/env-key-hits.txt"
+ENV_KEY_WARN_HITS="$TMP_DIR/env-key-warn-hits.txt"
+ENV_KEY_INFO_HITS="$TMP_DIR/env-key-info-hits.txt"
+CONTENT_HITS="$TMP_DIR/content-hits.txt"
+TRACKED_SENSITIVE="$TMP_DIR/tracked-sensitive.txt"
+MODULE_CHANGE_HITS="$TMP_DIR/module-change-hits.txt"
+DOCS_MD_HITS="$TMP_DIR/docs-md-hits.txt"
+SNAPSHOT_HITS="$TMP_DIR/snapshot-hits.txt"
+NOTES_OR_CONV_HITS="$TMP_DIR/notes-or-conv-hits.txt"
+NEW_MODULE_FILES="$TMP_DIR/new-module-files.txt"
+BASTION_GUARD_HITS="$TMP_DIR/bastion-guard-hits.txt"
+
+if [[ "$MODE" == "push" ]]; then
+  upstream_ref="${SAFE_REPO_AUDIT_UPSTREAM:-@{upstream}}"
+  if git rev-parse --verify "$upstream_ref" >/dev/null 2>&1; then
+    PUSH_BASE="$(git merge-base HEAD "$upstream_ref")"
+  else
+    PUSH_BASE="$(git hash-object -t tree /dev/null)"
+  fi
+  PUSH_RANGE="${PUSH_BASE}..HEAD"
+fi
+
+{
+  if [[ "$MODE" == "push" ]]; then
+    git diff --name-only "$PUSH_RANGE"
+  else
+    git diff --name-only
+    git diff --cached --name-only
+    git ls-files --others --exclude-standard
+  fi
+} | sed '/^$/d' | sort -u > "$CHANGED_LIST"
+
+# Filter out noisy dependency/artifact paths for path-based checks.
+grep -Eiv \
+  '(^|/)(vendor|node_modules|\.venv[^/]*|wallet-diagnostics-[^/]+|status_snapshots|\.backups|\.git)(/|$)' \
+  "$CHANGED_LIST" > "$FILTERED_CHANGED_LIST" || true
+
+{
+  if [[ "$MODE" == "push" ]]; then
+    git diff -U0 --no-color "$PUSH_RANGE"
+  else
+    git diff -U0 --no-color
+    git diff --cached -U0 --no-color
+  fi
+} | awk '/^\+[^+]/ {print substr($0,2)}' > "$ADDED_LINES"
+
+echo "== Safe Repo Audit =="
+echo "Repo:    $REPO_ROOT"
+echo "Branch:  $BRANCH"
+echo "HEAD:    $HEAD_SHA"
+echo "Mode:    $MODE"
+if [[ "$MODE" == "push" ]]; then
+  echo "Range:   ${PUSH_RANGE}"
+fi
+echo "Changed: $(wc -l < "$CHANGED_LIST" | tr -d ' ') files"
+echo "Scan set (noise-filtered): $(wc -l < "$FILTERED_CHANGED_LIST" | tr -d ' ') files"
+echo
+
+WARNINGS=0
+DOC_GUARD_BYPASS="${SAFE_REPO_AUDIT_ALLOW_DOC_GAP:-0}"
+
+if [[ ! -s "$CHANGED_LIST" ]]; then
+  echo "OK: no local changes detected."
+  exit 0
+fi
+
+register_warning() {
+  local message="$1"
+  if [[ "$DOC_GUARD_BYPASS" == "1" ]]; then
+    echo "BYPASS: $message"
+    echo "BYPASS: SAFE_REPO_AUDIT_ALLOW_DOC_GAP=1 miatt dokumentációs gate nem blokkol."
+    echo
+    return 0
+  fi
+  WARNINGS=$((WARNINGS + 1))
+  echo "WARN: $message"
+  echo
+}
+
+# 1) Risky file name patterns in changed/untracked files.
+grep -Ein -- \
+  '(^|/)\.env($|\.|/)|\.pem$|\.p12$|\.pfx$|\.key$|(^|/)id_rsa($|\.|/)|(^|/)(secrets?|credentials?)(/|$)|password|passwd' \
+  "$FILTERED_CHANGED_LIST" > "$RISKY_NAME_HITS" || true
+
+if [[ -s "$RISKY_NAME_HITS" ]]; then
+  WARNINGS=$((WARNINGS + 1))
+  echo "WARN: potentially sensitive changed file paths:"
+  sed -E 's/^[0-9]+://' "$RISKY_NAME_HITS" | sed -n '1,80p'
+  echo
+fi
+
+# 2) Secret-like strings in added lines (staged + unstaged diffs).
+grep -Ein -- \
+  '-----BEGIN (RSA|EC|OPENSSH|DSA|PGP) PRIVATE KEY-----|AKIA[0-9A-Z]{16}|AIza[0-9A-Za-z_-]{35}|ghp_[A-Za-z0-9]{36}|github_pat_[A-Za-z0-9_]{80,}|xox[baprs]-[A-Za-z0-9-]{10,}|(api[_-]?key|secret|token|password|passwd|client_secret)[[:space:]]*[:=][[:space:]]*["'"'"'][^"'"'"']{12,}["'"'"']' \
+  "$ADDED_LINES" > "$CONTENT_HITS" || true
+
+if [[ -s "$CONTENT_HITS" ]]; then
+  WARNINGS=$((WARNINGS + 1))
+  echo "WARN: secret-like values detected in added lines (first 40):"
+  sed -n '1,40p' "$CONTENT_HITS"
+  echo
+fi
+
+# 3) Extra check for env/deploy files: show only key names, never values.
+while IFS= read -r file; do
+  [[ -n "$file" ]] || continue
+  if [[ "$file" =~ (^|/)\.env($|\.|/) || "$file" =~ (^|/)\.deploy\.(production|staging)\.env$ ]]; then
+    {
+      git diff -U0 --no-color -- "$file"
+      git diff --cached -U0 --no-color -- "$file"
+    } | awk '/^\+[^+]/ {print substr($0,2)}' \
+      | grep -E '^[A-Za-z_][A-Za-z0-9_]*=' \
+      | awk -F= '
+          {
+            key=$1
+            val=substr($0, index($0, "=") + 1)
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "", key)
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "", val)
+            gsub(/^["'"'"']|["'"'"']$/, "", val)
+            low=tolower(val)
+            if (val == "") next
+            if (low ~ /^(example|sample|dummy|changeme|change_me|todo)$/) next
+            if (low ~ /^your_[a-z0-9_]+$/) next
+            if (val ~ /^<.*>$/) next
+            print key
+          }
+        ' \
+      | sort -u \
+      | while IFS= read -r key; do
+          [[ -n "$key" ]] && echo "$file :: $key"
+        done >> "$ENV_KEY_HITS" || true
+  fi
+done < "$FILTERED_CHANGED_LIST"
+
+if [[ -s "$ENV_KEY_HITS" ]]; then
+  while IFS= read -r line; do
+    [[ -n "$line" ]] || continue
+    key="${line##*:: }"
+    key_up="$(printf '%s' "$key" | tr '[:lower:]' '[:upper:]')"
+    if printf '%s' "$key_up" | grep -Eq '(^|_)(SECRET|TOKEN|PASSWORD|PASSWD|PRIVATE|CLIENT_SECRET|ACCESS_KEY|API_KEY|AUTH|CREDENTIAL|CERT|PEM|P12)(_|$)|(^|_)KEY($|_)'; then
+      echo "$line" >> "$ENV_KEY_WARN_HITS"
+    else
+      echo "$line" >> "$ENV_KEY_INFO_HITS"
+    fi
+  done < "$ENV_KEY_HITS"
+fi
+
+if [[ -s "$ENV_KEY_WARN_HITS" ]]; then
+  WARNINGS=$((WARNINGS + 1))
+  echo "WARN: sensitive-looking env keys modified (values hidden):"
+  sed -n '1,80p' "$ENV_KEY_WARN_HITS"
+  echo
+fi
+
+if [[ -s "$ENV_KEY_INFO_HITS" ]]; then
+  echo "INFO: non-sensitive env keys modified (values hidden):"
+  sed -n '1,80p' "$ENV_KEY_INFO_HITS"
+  echo
+fi
+
+# 4) Documentation continuity checks for module-level changes.
+grep -E -- \
+  '^(apps/|src/|wp-content/mu-plugins/|wp-content/plugins/|mu-plugins/|scripts/|bin/|services/|config/|types/|packages/|lib/|tools/)' \
+  "$FILTERED_CHANGED_LIST" \
+  | grep -Eiv -- \
+    '(^|/)(docs/|conversation-summaries/|chatgpt-history/|\.codex/|vendor/|node_modules/|status_snapshots/)' \
+  > "$MODULE_CHANGE_HITS" || true
+
+if [[ -s "$MODULE_CHANGE_HITS" ]]; then
+  echo "INFO: module-level changes detected:"
+  sed -n '1,60p' "$MODULE_CHANGE_HITS"
+  echo
+
+  grep -E -- '^docs/[^[:space:]]+\.(md|mdx)$' "$FILTERED_CHANGED_LIST" > "$DOCS_MD_HITS" || true
+  grep -E -- '^system-status-snapshot\.md$' "$FILTERED_CHANGED_LIST" > "$SNAPSHOT_HITS" || true
+
+  if [[ -f "$REPO_ROOT/notes.md" || -d "$REPO_ROOT/conversation-summaries" ]]; then
+    grep -E -- '^(notes\.md|conversation-summaries/[^[:space:]]+\.md)$' "$FILTERED_CHANGED_LIST" > "$NOTES_OR_CONV_HITS" || true
+  fi
+
+  if [[ ! -s "$DOCS_MD_HITS" ]]; then
+    register_warning "module change without docs/*.md update (minimum 1 docs markdown frissítés kötelező)."
+  fi
+
+  if [[ ! -s "$SNAPSHOT_HITS" ]]; then
+    register_warning "module change without system-status-snapshot.md update (impactall/snapshot folytonosság sérül)."
+  fi
+
+  if [[ -f "$REPO_ROOT/notes.md" || -d "$REPO_ROOT/conversation-summaries" ]]; then
+    if [[ ! -s "$NOTES_OR_CONV_HITS" ]]; then
+      register_warning "module change without notes.md vagy conversation-summaries/* frissítés."
+    fi
+  fi
+fi
+
+# 5) New module files must extend bastion/guard documentation.
+{
+  if [[ "$MODE" == "push" ]]; then
+    git diff --name-only --diff-filter=A "$PUSH_RANGE"
+  else
+    git diff --name-only --diff-filter=A
+    git diff --cached --name-only --diff-filter=A
+    git ls-files --others --exclude-standard
+  fi
+} | sed '/^$/d' | sort -u > "$NEW_MODULE_FILES"
+
+grep -E -- \
+  '^(apps/|src/|wp-content/mu-plugins/|wp-content/plugins/|mu-plugins/|services/|types/|packages/|lib/)' \
+  "$NEW_MODULE_FILES" \
+  | grep -Eiv -- \
+    '(^|/)(docs/|conversation-summaries/|chatgpt-history/|\.codex/|vendor/|node_modules/|__tests__/|tests?/)' \
+  > "$NEW_MODULE_FILES.filtered" || true
+
+if [[ -s "$NEW_MODULE_FILES.filtered" ]]; then
+  grep -E -- \
+    '(^|/)(docs/bastion-guard-status\.md|docs/.*(bastion|guard).*\.(md|mdx|json|ya?ml)|scripts/.*guard.*\.(sh|ts|js|mjs|py)|\.codex/guards/)' \
+    "$FILTERED_CHANGED_LIST" > "$BASTION_GUARD_HITS" || true
+
+  if [[ ! -s "$BASTION_GUARD_HITS" ]]; then
+    echo "INFO: new module files detected (first 40):"
+    sed -n '1,40p' "$NEW_MODULE_FILES.filtered"
+    echo
+    register_warning "new module without bastion/guard extension update (pl. docs/bastion-guard-status.md)."
+  fi
+fi
+
+# 6) Informational: tracked sensitive files already inside repository.
+git ls-files | grep -Ei -- \
+  '(^|/)\.env($|\.|/)|\.pem$|\.p12$|\.pfx$|\.key$|(^|/)id_rsa($|\.|/)|(^|/)(secrets?|credentials?)(/|$)|master\.key$|credentials\.yml\.enc$' \
+  > "$TRACKED_SENSITIVE" || true
+
+if [[ -s "$TRACKED_SENSITIVE" ]]; then
+  echo "INFO: tracked sensitive-looking files in repo: $(wc -l < "$TRACKED_SENSITIVE" | tr -d ' ')"
+  sed -n '1,40p' "$TRACKED_SENSITIVE"
+  echo
+fi
+
+if [[ "$WARNINGS" -eq 0 ]]; then
+  echo "RESULT: PASS (no new obvious secret leak signal in local changes)"
+  exit 0
+fi
+
+echo "RESULT: WARN ($WARNINGS categories triggered)"
+if [[ "$STRICT" -eq 1 ]]; then
+  echo "STRICT MODE: failing due to warnings."
+  exit 2
+fi
+
+echo "Non-strict mode: exit 0 (warnings only)."
+exit 0

--- a/system-status-snapshot.md
+++ b/system-status-snapshot.md
@@ -1278,3 +1278,15 @@ _Manual update: 2026-03-05 15:41:50 CET_
 - `impactall` futás a monorepo gyökérből: `IMPACTALL_SKIP_SAFE_AUDIT=1 IMPACTALL_AUTO_NOTES=0 ./impactall`.
 - Health summary (futásból): staging `HTTP 403 / 287 ms`, production `HTTP 403 / 257 ms`; guard összegzés `1/1 PASS`, WARN/FAIL nélkül.
 - Clean strict audit PASS: `scripts/safe-repo-audit.sh --repo /Users/bujdosoarnold/Developer/GitHub/.worktrees/impactshop-notes-checkpoint-2026-03-05 --strict` -> `OK: no local changes detected.`
+
+---
+_Manual update: 2026-03-08 22:15:00 CET_
+
+### One-path enforcement applied
+
+- Enforced workflow gates updated: `pre-commit` blocks `main/master` commit, `pre-push` blocks direct `main/master` push.
+- Push audit standardized to `safe-repo-audit.sh --strict --mode push`.
+- Hook installer hardened for worktree compatibility (`git rev-parse --git-path hooks`).
+- `scripts/git-health-check.sh` validates required policy files + hook policy markers.
+
+**Baseline referencia:** impactshop-baseline-2025-11-02.md


### PR DESCRIPTION
## Team Rule (Mandatory)

- Every PR must include the `PR Exit Checklist (Required)` block in the PR body.
- PR is not merge-ready without this block (`PR Checklist Guard` CI enforces it).
- New clone/worktree bootstrap: run `bash scripts/install-hooks-all.sh` from repo/workspace root.

## Summary

- Scope: hook standardization + PR exit checklist enforcement + one-path workflow hardening.
- Why: unify commit/push/PR path across active repos and remove false-block cases.
- Risk: low (workflow/guard scripts + docs only; no runtime prod feature logic changed).

## Why `--mode push` was needed

- Previous strict local scan could fail push because of unrelated local dirty files/worktree noise.
- `safe-repo-audit.sh --strict --mode push` checks only the actual pushed commit range.
- This removes false-block while keeping strict secret/path/policy guard on pushed content.

## Validation

- `bash scripts/install-hooks-all.sh`
- `bash scripts/git-health-check.sh`
- `bash scripts/standard-path-health.sh` (workspace-level)
- Push pre-hook audit passed with `Mode: push` in all 3 repos.

## Rollback

- Revert policy commits per repo (single PR revert / git revert).
- Re-run hook installer from previous revision if rollback is needed.
- Emergency bypass (approval required):
  - `IMPACT_POLICY_ALLOW_MAIN_COMMIT=1`
  - `IMPACT_POLICY_ALLOW_MAIN_PUSH=1`

## PR Exit Checklist (Required)

- [ ] 1. Work was done on dedicated branch/worktree (not `main`)
- [ ] 2. Relevant build/tests ran and are green
- [ ] 3. `safe-repo-audit.sh --strict --mode push` is green
- [ ] 4. `system-status-snapshot.md` updated for module change
- [ ] 5. At least one `docs/*.md` updated for module change
- [ ] 6. `notes.md` or `conversation-summaries/*` updated (notes-context repos)
- [ ] 7. `docs/bastion-guard-status.md` updated when new module file was added
- [ ] 8. Deploy guard + smoke checks are logged (if deploy happened)
- [ ] 9. Backup/rollback path is recorded
- [ ] 10. PR description includes scope, risk, validation, deploy/rollback notes
