### PR TITLE
Restore Ads Watch start button on initial load

### DIFF
--- a/docs/ads-watch-initial-banner-block-2026-03-26.md
+++ b/docs/ads-watch-initial-banner-block-2026-03-26.md
@@ -1,0 +1,20 @@
+# Ads Watch initial banner block fix
+
+Date: 2026-03-26
+
+## Problem
+
+`impact-challenge` page load could immediately start the idle auto-banner loop inside the player area. That banner sat above the player and hid the `Reklám megtekintése` button on mobile and desktop, making Ads Watch appear frozen before the user could start a video.
+
+## Change
+
+- removed the eager `loadAutoBanner()` call from page initialization
+- changed the legacy idle auto-banner completion path to hide itself and return control to the player instead of chaining into another banner
+- bumped `IMPACTSHOP_ADS_WATCH_VERSION` to `2.5.31` for CDN/browser cache bust
+
+## Verification
+
+- `node --check wp-content/mu-plugins/impactshop-ads-watch.js`
+- `php -l wp-content/mu-plugins/impactshop-ads-watch.php`
+- production page references `impactshop-ads-watch.js?ver=2.5.31`
+- live Playwright snapshot shows `▶ Reklám megtekintése` again on desktop and mobile viewport

--- a/notes.md
+++ b/notes.md
@@ -6446,3 +6446,10 @@ Saved 43 promotions to /Users/bujdosoarnold/Documents/GitHub/ai-agent/tools/out/
 - `impactshop-ads-watch.php`: verzió emelve `2.5.30`-ra Cloudflare cache bust miatt
 - Deploy: célzott rsync a production MU-plugin könyvtárba
 - Live check: `/impact-challenge/` már `impactshop-ads-watch.js?ver=2.5.30`-at tölti
+
+## 2026-03-26 — Ads Watch induló autobanner blokkolta a start gombot
+- root cause: oldalbetöltéskor automatikusan indult a `loadAutoBanner()` loop, ami ráült a playerre
+- következmény: a `Reklám megtekintése` gomb mobilon és desktopon sem látszott, az oldal lefagyottnak tűnt
+- fix: eager `loadAutoBanner()` eltávolítva, a legacy banner completion pedig visszaadja a kontrollt a playernek
+- verzió: `2.5.31`
+- live ellenőrzés: Playwright snapshoton újra látszik a `▶ Reklám megtekintése` gomb mobil viewporton is

--- a/system-status-snapshot.md
+++ b/system-status-snapshot.md
@@ -466,3 +466,9 @@ PHP lint ok for identity/gamification modules
 - `impactshop-ads-watch.js` now tracks outbound sponsor CTA / autobanner tab opens and reloads on return when Safari restores the original tab in a bad visual state.
 - `impactshop-ads-watch.php` version bumped to `2.5.30` for Cloudflare/browser cache bust.
 - Live verification: `/impact-challenge/` references `impactshop-ads-watch.js?ver=2.5.30`; direct header check returned `cf-cache-status: MISS`.
+
+## 2026-03-26 — Ads Watch initial banner block fix
+- `impactshop-ads-watch.js`: page init no longer starts the idle auto-banner loop over the player.
+- legacy `loadAutoBanner()` completion now hides the banner and returns control to the start state instead of chaining forever.
+- `impactshop-ads-watch.php`: version bumped to `2.5.31`.
+- Live verification: desktop and mobile Playwright snapshots again show `▶ Reklám megtekintése` on `/impact-challenge/`.

--- a/wp-content/mu-plugins/impactshop-ads-watch.js
+++ b/wp-content/mu-plugins/impactshop-ads-watch.js
@@ -134,9 +134,6 @@
         initChallengeCountdown();
         loadUserStatus();
         scheduleTallyLoad();
-        if (!state.unifiedDisplay) {
-            loadAutoBanner();
-        }
     });
 
     function initIdentityBridge() {
@@ -3349,7 +3346,15 @@
                 watchReward: '+1 pont, +1 szavazat',
                 clickReward: '+5 pont, +5 szavazat'
             });
-            startBannerProgress($banner, { duration: 5000, onComplete: loadAutoBanner });
+            startBannerProgress($banner, {
+                duration: 5000,
+                onComplete: function () {
+                    state.currentAutoBanner = null;
+                    $banner.prop('hidden', true);
+                    updateWatchButton();
+                    hideVideoInfoPanel();
+                }
+            });
         }).fail(function () {
             $banner.prop('hidden', true);
         });

--- a/wp-content/mu-plugins/impactshop-ads-watch.php
+++ b/wp-content/mu-plugins/impactshop-ads-watch.php
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
 // CONSTANTS
 // ─────────────────────────────────────────────────────────────────────────────
 
-define('IMPACTSHOP_ADS_WATCH_VERSION', '2.5.30');
+define('IMPACTSHOP_ADS_WATCH_VERSION', '2.5.31');
 define('IMPACTSHOP_ADS_WATCH_SCHEMA_VERSION', '8');
 define('IMPACTSHOP_ADS_DONATION_POOL', 500000); // Ft
 


### PR DESCRIPTION
## Summary
- stop starting the idle autobanner loop over the player on page load
- return legacy autobanner completion to the normal player start state instead of chaining forever
- bump Ads Watch asset version to 2.5.31 and record continuity docs

## Verification
- node --check wp-content/mu-plugins/impactshop-ads-watch.js
- php -l wp-content/mu-plugins/impactshop-ads-watch.php
- live page references impactshop-ads-watch.js?ver=2.5.31
- Playwright snapshot shows  again on desktop and mobile viewport