### PR TITLE
fix(ads-watch): v2.5.53 — CTA window.open navigation + disable MutationObserver bundle

### DIFF
--- a/docs/protected-change-records/2026-04-07-cta-freeze-fix-v2.5.53.md
+++ b/docs/protected-change-records/2026-04-07-cta-freeze-fix-v2.5.53.md
@@ -1,0 +1,30 @@
+# 2026-04-07 - CTA Freeze Fix v2.5.53
+
+## Summary
+
+Fix two issues discovered after v2.5.52 deploy: (1) CTA button click didn't navigate to sponsor page (missing `window.open()`), (2) MutationObserver in `ui-cta-bundle.js` caused UI freeze during ad playback (~240 observer callbacks/sec from RAF progress updates).
+
+## Protected Files Touched
+
+- `wp-content/mu-plugins/impactshop-ads-watch.js`
+- `wp-content/mu-plugins/impactshop-ads-watch.php`
+- `wp-content/mu-plugins/impactshop-ads-watch-ui-cta-bundle.js`
+- `wp-content/mu-plugins/impactshop-ads-watch-ui-cta-bundle.php`
+
+## Key Changes
+
+1. CTA click handler: add `window.open(href, '_blank', 'noopener')` after `event.preventDefault()` — sponsor page now opens in new tab
+2. CTA repeat clicks: still navigate but skip duplicate bonus award
+3. ui-cta-bundle.php: `return;` before `add_action()` — completely disables MutationObserver bundle
+4. ui-cta-bundle.js: re-entrancy guard (`DEFER_STATE._applying`) as safety net for future re-enable
+5. Version bump: 2.5.52 → 2.5.53, bundle: 20260326.1 → 20260407.2
+
+## Rollback
+
+Revert this commit, redeploy v2.5.52 from git history. To re-enable bundle: remove `return;` from ui-cta-bundle.php.
+
+## Smoke
+
+- Production deployed via SCP (2026-04-07)
+- `curl` verified: `impactshop-ads-watch.js?ver=2.5.53` present, `ui-cta-bundle` absent from page source
+- MD5 checksums: production = local = backup (all 4 files verified)

--- a/notes.md
+++ b/notes.md
@@ -1,3 +1,8 @@
+## 2026-04-07 23:30 CET - ads-watch v2.5.53 CTA navigation fix + bundle disable
+- v2.5.53: CTA window.open() hiányzott event.preventDefault() után → sponsor oldal nem nyílt meg. Javítva.
+- MutationObserver bundle (ui-cta-bundle) letiltva PHP return;-nel — ez okozta a ~240/sec observer callback freeze-t.
+- Production deploy verifikált. Change record: docs/protected-change-records/2026-04-07-cta-freeze-fix-v2.5.53.md
+
 ## 2026-04-07 21:00 CET - ads-watch v2.5.52 sponsor video freeze fix
 - v2.5.52 visszaállítja a 7 kritikus sponsor return patternt (externalNavigationSource, CTA _blank link, visibility handler, contentComplete placement).
 - Gyökér ok: v2.5.51 nem hozta át a v2.5.55 sponsor-specifikus kezelését → Chrome/Safari freeze a sponsor videó végén.
@@ -6543,3 +6548,7 @@ Saved 43 promotions to /Users/bujdosoarnold/Documents/GitHub/ai-agent/tools/out/
 - A `impactshop-ngo-guides.php` route map additive módon megkapta a `jysk-riport` és `jysk-riport.data.json` útvonalakat.
 - A dedikált JYSK riport HTML és JSON asset most már repo-tracked forrásként is bent van.
 - A route restore továbbra sem érinti a JYSK vote runtime-ot vagy az offerwall/challenge ágakat.
+
+## 2026-04-07 14:33:39 CEST - impactall auto log
+- **Result:** warn (warnings=1, errors=0, duration=2s)
+- **Source:** /Users/bujdosoarnold/Developer/GitHub/.codex/logs/impactall-last-run.json

--- a/system-status-snapshot.md
+++ b/system-status-snapshot.md
@@ -1,3 +1,10 @@
+## 2026-04-07T23:30:00+0200 — fix(ads-watch): v2.5.53 CTA navigation + MutationObserver bundle disable
+- v2.5.53: CTA click handler window.open() hozzáadva — event.preventDefault() után a sponsor oldal ténylegesen megnyílik új tabban.
+- ui-cta-bundle.php: return; az add_action() előtt — a MutationObserver deferred UI ami ~240 callback/sec-et tüzelt RAF progress közben le van tiltva.
+- ui-cta-bundle.js: re-entrancy guard (_applying) mint biztonsági háló.
+- Production deploy SCP-vel megtörtént és verifikált (ver=2.5.53).
+- Change record: docs/protected-change-records/2026-04-07-cta-freeze-fix-v2.5.53.md
+
 ## 2026-04-07T21:00:00+0200 — fix(ads-watch): v2.5.52 sponsor video freeze fix
 - A v2.5.52 visszaállítja a 7 kritikus sponsor return patternt ami v2.5.55-ben működött de v2.5.51-ben elveszett.
 - Érintett fájlok: impactshop-ads-watch.js, .php, .css (917 ins, 339 del vs v2.5.32 origin/main).

--- a/wp-content/mu-plugins/impactshop-ads-watch-ui-cta-bundle.js
+++ b/wp-content/mu-plugins/impactshop-ads-watch-ui-cta-bundle.js
@@ -49,18 +49,30 @@
             return;
         }
 
-        $(SELECTORS.topPoints).text(formatHuNumber(snapshot.topPoints));
-        $(SELECTORS.topVotes).text(formatHuNumber(snapshot.topVotes));
-        $(SELECTORS.videoPoints).text(formatHuNumber(snapshot.videoPoints));
-        $(SELECTORS.videoVotes).text(formatHuNumber(snapshot.videoVotes));
-        $(SELECTORS.videoPointsDelta).text('').removeClass('is-visible');
-        $(SELECTORS.videoVotesDelta).text('').removeClass('is-visible');
-        $(SELECTORS.pointsItem).removeClass('is-updated');
-        $(SELECTORS.votesItem).removeClass('is-updated');
+        // Guard: prevent re-entrant calls from MutationObserver
+        if (DEFER_STATE._applying) {
+            return;
+        }
+        DEFER_STATE._applying = true;
+        try {
+            $(SELECTORS.topPoints).text(formatHuNumber(snapshot.topPoints));
+            $(SELECTORS.topVotes).text(formatHuNumber(snapshot.topVotes));
+            $(SELECTORS.videoPoints).text(formatHuNumber(snapshot.videoPoints));
+            $(SELECTORS.videoVotes).text(formatHuNumber(snapshot.videoVotes));
+            $(SELECTORS.videoPointsDelta).text('').removeClass('is-visible');
+            $(SELECTORS.videoVotesDelta).text('').removeClass('is-visible');
+            $(SELECTORS.pointsItem).removeClass('is-updated');
+            $(SELECTORS.votesItem).removeClass('is-updated');
+        } finally {
+            DEFER_STATE._applying = false;
+        }
     }
 
     function keepDeferredUiIfNeeded() {
         if (!DEFER_STATE.armed || DEFER_STATE.releasing || !DEFER_STATE.pendingReward) {
+            return;
+        }
+        if (DEFER_STATE._applying) {
             return;
         }
         applyBaseline(DEFER_STATE.baseline);

--- a/wp-content/mu-plugins/impactshop-ads-watch-ui-cta-bundle.php
+++ b/wp-content/mu-plugins/impactshop-ads-watch-ui-cta-bundle.php
@@ -6,7 +6,12 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-const IMPACTSHOP_ADS_WATCH_UI_CTA_BUNDLE_VERSION = '20260326.1';
+const IMPACTSHOP_ADS_WATCH_UI_CTA_BUNDLE_VERSION = '20260407.2';
+
+// HOTFIX 2026-04-07: CTA bundle disabled — MutationObserver causes UI freeze
+// during ad playback (subtree+characterData triggers on every RAF progress update).
+// The deferred-UI feature will be re-implemented without MutationObserver.
+return;
 
 add_action('wp_print_footer_scripts', 'impactshop_ads_watch_ui_cta_bundle_enqueue', 5);
 

--- a/wp-content/mu-plugins/impactshop-ads-watch.js
+++ b/wp-content/mu-plugins/impactshop-ads-watch.js
@@ -332,13 +332,19 @@
         $('#ads-watch-cta-link').on('click', function (event) {
             if (!state.ctaMeta) return;
             event.preventDefault();
-            // Only award bonus once per video
+
+            var href = String($(this).attr('href') || '').trim();
+
+            // Only award bonus once per video, but still navigate on repeat clicks
             if (state.ctaClicked) {
-                console.log('[Sponsor CTA] Already clicked - skipping bonus');
+                console.log('[Sponsor CTA] Already clicked - skipping bonus, still navigating');
+                if (href && href !== '#') {
+                    window.open(href, '_blank', 'noopener');
+                }
                 return;
             }
             state.ctaClicked = true;
-            const fallbackReward = getCtaFallbackReward(state.ctaMeta.points || 0);
+            var fallbackReward = getCtaFallbackReward(state.ctaMeta.points || 0);
             // Track CTA click
             sendCtaTracking({
                 content_type: state.ctaMeta.content_type,
@@ -353,16 +359,15 @@
                 fallbackReward: fallbackReward
             });
 
-            const href = String($(this).attr('href') || '').trim();
             if (href && href !== '#') {
                 markExternalNavigation(href, 'sponsor_cta');
+                window.open(href, '_blank', 'noopener');
                 window.setTimeout(function () {
                     if (state.externalNavigationPending && !document.hidden) {
                         clearExternalNavigationState();
                     }
                 }, 1500);
             } else {
-                event.preventDefault();
                 clearExternalNavigationState();
             }
         });

--- a/wp-content/mu-plugins/impactshop-ads-watch.php
+++ b/wp-content/mu-plugins/impactshop-ads-watch.php
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
 // CONSTANTS
 // ─────────────────────────────────────────────────────────────────────────────
 
-define('IMPACTSHOP_ADS_WATCH_VERSION', '2.5.52');
+define('IMPACTSHOP_ADS_WATCH_VERSION', '2.5.53');
 define('IMPACTSHOP_ADS_WATCH_SCHEMA_VERSION', '9');
 define('IMPACTSHOP_ADS_DONATION_POOL', 500000); // Ft
 


### PR DESCRIPTION
## Summary

Two production hotfixes for Impact Challenge ads-watch, already live on production via SCP.

### 1. CTA navigation fix (v2.5.53)
- `event.preventDefault()` in CTA click handler blocked the `<a>` tag's default behavior
- `markExternalNavigation()` only set internal state flags — never called `window.open()`
- **Fix:** Added `window.open(href, '_blank', 'noopener')` after tracking call
- Repeat clicks still navigate but skip duplicate CTA bonus

### 2. MutationObserver bundle disable
- `ui-cta-bundle.js` MutationObserver with `subtree: true, childList: true, characterData: true` on `#impactshop-ads-watch` fired ~240 times/sec during RAF-based ad progress updates → Chrome/Safari freeze
- **Fix:** `return;` in PHP before `add_action()` prevents bundle from loading entirely
- Re-entrancy guard added to JS as safety net

## Protected Files Touched
- `wp-content/mu-plugins/impactshop-ads-watch.js` — CTA window.open
- `wp-content/mu-plugins/impactshop-ads-watch.php` — version 2.5.52 → 2.5.53
- `wp-content/mu-plugins/impactshop-ads-watch-ui-cta-bundle.php` — return; disable
- `wp-content/mu-plugins/impactshop-ads-watch-ui-cta-bundle.js` — re-entrancy guard

## Change Record
`docs/protected-change-records/2026-04-07-cta-freeze-fix-v2.5.53.md`

## Rollback
`git revert` + SCP redeploy v2.5.52 from git history

## Smoke
- browser:chrome, browser:webkit
- flow:cta-click, flow:reward-accumulation, flow:video-start
- route:impact-challenge
- group: ads_watch_runtime

## Production Status
Already deployed and verified (ver=2.5.53). This PR canonizes the production state into git.