### PR TITLE
fix: canonicalize ads-watch mobile resize hotfix

### DIFF
--- a/docs/debug/ads-watch-v2.5.63-mobile-freeze-postmortem.md
+++ b/docs/debug/ads-watch-v2.5.63-mobile-freeze-postmortem.md
@@ -10,6 +10,26 @@
 
 ---
 
+## 0.1 Utólagos korrekció — 2026-04-19 resize-hotfix follow-up
+
+> Ez a rész **nem** a v2.5.63 hotfix része, hanem egy későbbi, külön mobil-only incidenskör tanulsága.
+
+- A v2.5.65 környékén új, mobil-specifikus gyanú merült fel: a `handleWindowResize()` minden viewport-változásnál közvetlenül hívta az `adsManager.resize(...)` ágat.
+- Biztonságos, rollback-first hotfix készült, amely:
+  - rejtett dokumentumnál nem resize-ol
+  - kis vagy duplikált méretváltozásokat eldobj
+  - resize burst alatt throttlingot alkalmaz
+- A deploy kivizsgálás közben fontos környezeti drift derült ki:
+  - a production env szerinti célpath `/home/sharityh/app/.../impactshop-ads-watch.js` volt
+  - a publikus `app.sharity.hu` asset hash-e viszont ténylegesen az `/home/sharityh/app-staging/.../impactshop-ads-watch.js` példánnyal egyezett
+  - emiatt a hotfixet mindkét pathra ki kellett tenni backup + rollback mellett
+- A szerveroldali origin frissült, de a publikus URL továbbra is Cloudflare `cf-cache-status: HIT` állapotban a régi assetet szolgálta.
+- Következtetés:
+  - a runtime hotfix önmagában nem elég, ha az asset path vagy CDN cache driftben van
+  - külön purge vagy verzióbump nélkül a kliensoldali validáció hamis negatív lehet
+
+---
+
 ## 1. Összefoglaló idővonal — "Hete szenvedtünk vele"
 
 | Dátum | Esemény | Érintett platformok |

--- a/docs/debug/ads-watch-v2.5.63-mobile-freeze-postmortem.md
+++ b/docs/debug/ads-watch-v2.5.63-mobile-freeze-postmortem.md
@@ -17,7 +17,7 @@
 - A v2.5.65 környékén új, mobil-specifikus gyanú merült fel: a `handleWindowResize()` minden viewport-változásnál közvetlenül hívta az `adsManager.resize(...)` ágat.
 - Biztonságos, rollback-first hotfix készült, amely:
   - rejtett dokumentumnál nem resize-ol
-  - kis vagy duplikált méretváltozásokat eldobj
+  - kis vagy duplikált méretváltozásokat eldob
   - resize burst alatt throttlingot alkalmaz
 - A deploy kivizsgálás közben fontos környezeti drift derült ki:
   - a production env szerinti célpath `/home/sharityh/app/.../impactshop-ads-watch.js` volt

--- a/docs/impactshop-guard-deploy-path-fix-followup-2026-04-20.md
+++ b/docs/impactshop-guard-deploy-path-fix-followup-2026-04-20.md
@@ -1,0 +1,47 @@
+# Impact Shop Guard Deploy-Path Fix Follow-Up
+
+## Cél
+
+A guard deploy infrastruktúrát össze kell igazítani a tényleges production kiszolgálási útvonallal, hogy a következő protected deploy már ne incidensúton menjen ki.
+
+## Probléma
+
+- A jelenlegi runbook szerint a production deploy célpath: `/home/sharityh/app`
+- A 2026-04-19-es incidens során a publikus asset-egyezés alapján az `/home/sharityh/app-staging` is érintettnek bizonyult
+- Ez sérti a `Guard scope and source of truth` és a `Canonical guard workflow path` elvet
+
+## Kötelező korrekciók
+
+1. `.deploy.production.env`
+- ellenőrizni kell, hogy a benne lévő `REMOTE_WP_PATH` a tényleges production originre mutat-e
+
+2. `docs/impactshop-deploy.md`
+- a runbook csak a valós, auditált deploy pathot nevezheti ki production truth-nak
+
+3. `bin/impactshop-guard-deploy.sh`
+- ellenőrizni kell, hogy ugyanazt a pathot használja, mint a dokumentáció és a live site
+
+4. `bin/deploy-wpcontent-map.sh`
+- production mapping során explicit ellenőrzés kell a tényleges célpathra
+
+5. post-deploy verifikáció
+- az ellenőrzésnek nem elég a HTML route vagy health endpoint
+- kötelező legyen:
+  - asset URL
+  - asset hash
+  - `X-ImpactShop-AdsWatch-Version` vagy releváns runtime header
+
+## Kész állapot
+
+Ezt akkor tekintjük lezártnak, ha:
+
+- a dokumentált production path és a live origin egyezik
+- a guard deploy ugyanarra a pathra ír
+- a post-deploy smoke ezt hash/header szinten is igazolja
+- protected incidens esetén nem kell többé két pathra párhuzamos restore
+
+## Kapcsolódó anyagok
+
+- `docs/protected-change-records/2026-04-19-ads-watch-mobile-resize-throttle-hotfix.md`
+- `docs/impactshop-production-deploy-path-audit-2026-04-20.md`
+- `docs/impactshop-deploy.md`

--- a/docs/impactshop-production-deploy-path-audit-2026-04-20.md
+++ b/docs/impactshop-production-deploy-path-audit-2026-04-20.md
@@ -1,0 +1,46 @@
+# Impact Shop Production Deploy-Path Audit
+
+## Kontextus
+
+2026-04-19-én az `impactshop-ads-watch.js` mobil-freeze incidens hotfix deploy közben környezeti drift derült ki a dokumentált production deploy path és a ténylegesen publikus asset között.
+
+## Megfigyelések
+
+- A dokumentált production env jelenleg ezt tekinti source of truth-nak:
+  - `SSH_HOST="sharityh@s59.tarhely.com"`
+  - `REMOTE_WP_PATH="/home/sharityh/app"`
+- A publikus `https://app.sharity.hu/wp-content/mu-plugins/impactshop-ads-watch.js?ver=2.5.65` kezdeti hash-e nem az `/home/sharityh/app/.../impactshop-ads-watch.js` példánnyal, hanem az `/home/sharityh/app-staging/.../impactshop-ads-watch.js` fájllal egyezett.
+- A hotfixet ezért rollback-first módon mindkét pathra ki kellett vinni:
+  - `/home/sharityh/app`
+  - `/home/sharityh/app-staging`
+- A szerveroldali JS csere után a publikus asset továbbra is Cloudflare `HIT` cache-ből a régi tartalmat adta.
+- A végső cache-bypass lezárást az asset verzió `2.5.65 -> 2.5.66` bumpja adta.
+
+## Bizonyítékok
+
+- publikus HTML végül már ezt hivatkozta:
+  - `impactshop-ads-watch.js?ver=2.5.66`
+- publikus header:
+  - `X-ImpactShop-AdsWatch-Version: 2.5.66`
+- publikus JS hash:
+  - `3cd313f32a253cff5226a8322a971d7f529bba999cf3b698af22a88da48a614b`
+- az ismert szerveroldali példányokban a `2.5.66` konstans már bent van:
+  - `/home/sharityh/app/wp-content/mu-plugins/impactshop-ads-watch.php`
+  - `/home/sharityh/app-staging/wp-content/mu-plugins/impactshop-ads-watch.php`
+
+## Következtetés
+
+A production deploy út jelenleg nincs elég szorosan összezárva a ténylegesen kiszolgált origin/docroot valósággal. A guard deploy runbook és a valós live asset útvonal között legalább egy történeti vagy vhost szintű drift létezik.
+
+## Nyitott kérdések
+
+1. Az `app.sharity.hu` tényleges document rootja mi?
+2. Az `/home/sharityh/app-staging` miért tudott egyezni a publikus assettel productionön?
+3. Van-e olyan vhost/symlink/release mapping, amit a `.deploy.production.env` jelenleg nem ír le?
+4. A JS és a PHP miért ugyanabba a drift-mintába futott bele?
+
+## Döntési javaslat
+
+- A kanonikus production source of truth-ot külön audit eredménnyel ki kell mondani.
+- Addig a mostani incidens-hotfixet érvényes, de nem teljesen kanonikus restore-nak kell tekinteni.
+- A guard deploy infrastruktúrát csak az audit lezárása után szabad átállítani.

--- a/docs/protected-change-records/2026-04-19-ads-watch-mobile-resize-throttle-hotfix.md
+++ b/docs/protected-change-records/2026-04-19-ads-watch-mobile-resize-throttle-hotfix.md
@@ -1,0 +1,83 @@
+## Összefoglaló
+- szűk incidens-hotfix az Impact Challenge mobil-only freeze kivizsgálására és csillapítására
+- célzottan a `handleWindowResize()` / `adsManager.resize(...)` ág terhelését csökkenti
+- a javítás nem nyúl az observer ághoz, az külön lane marad
+
+## Protected files touched
+- `wp-content/mu-plugins/impactshop-ads-watch.js`
+
+## Érintett változás
+- új state mezők:
+  - `lastImaResizeAt`
+  - `lastImaResizeWidth`
+  - `lastImaResizeHeight`
+- a resize handler most:
+  - rejtett dokumentum alatt nem hív IMA resize-t
+  - kis vagy duplikált méretváltozást eldob
+  - resize burst alatt throttlingot használ
+  - csak valid konténerméretre hív `adsManager.resize(...)`
+
+## Kockázat
+- alacsony-közepes
+- a változás egyetlen protected runtime fájlra szűkül
+- fő regressziós felület: IMA overlay méretezés orientation vagy viewport váltás közben
+- nem érinti közvetlenül az action bar, offerwall, AyeT vagy Impact Shop route logikát
+
+## Rollback
+- lokális backup:
+  - `.codex/backups/20260419-113424-mobile-freeze-resize/impactshop-ads-watch.js.pre`
+- lokális visszaállítás:
+  - `.codex/backups/20260419-113424-mobile-freeze-resize/rollback.sh`
+- production rollback terv:
+  - a jelenlegi éles `impactshop-ads-watch.js` fájlról deploy előtt időbélyeges távoli backup készül
+  - regresszió esetén azonnali visszamásolás a távoli backupból
+  - utána `wp cache flush`
+- tényleges távoli backupok:
+  - `/home/sharityh/app/.codex-hotfix-backups/20260419-mobile-resize-hotfix/impactshop-ads-watch.js.20260419-133823.pre`
+  - `/home/sharityh/app-staging/.codex-hotfix-backups/20260419-mobile-resize-hotfix/impactshop-ads-watch.js.20260419-133941.pre`
+
+## Smoke scope
+- `route:impact-challenge`
+- `flow:video-start`
+- `flow:cta-click`
+- `flow:reward-accumulation`
+- `browser:webkit`
+- `browser:chrome`
+- `route:impactshop`
+- `flow:saved-offers-open`
+- `flow:go-deal`
+
+## Ellenőrzés
+- mobil shell load az `https://app.sharity.hu/impact-challenge/` route-on
+- videóindítás és IMA konténer stabilitás
+- `video -> tasks -> video -> stats`
+- külső CTA vagy sponsor visszatérés után nincs freeze
+- Impact Shop alap route smoke és nincs új közös runtime hiba
+
+## Megjegyzés
+- a `Clear-Site-Data` drift kifejezetten out of scope ebben az incidens-hotfixben
+- a `2.5.55` working snapshot csak baseline, nem automatikus rollback cél
+
+## Tényleges deploy kimenet
+- a szűk incidens-hotfix szerveroldalon sikeresen kiment mindkét érintett példányra:
+  - `/home/sharityh/app/wp-content/mu-plugins/impactshop-ads-watch.js`
+  - `/home/sharityh/app-staging/wp-content/mu-plugins/impactshop-ads-watch.js`
+- a deploy vizsgálat közben kiderült, hogy a publikus `https://app.sharity.hu/wp-content/mu-plugins/impactshop-ads-watch.js?ver=2.5.65`
+  régi hash-e nem az `app` path-szel, hanem az `app-staging` példánnyal egyezett
+- ez deploy-path / docroot driftre utal a production env dokumentáció és a ténylegesen kiszolgált asset között
+- a publikus URL a frissítés után is Cloudflare `HIT` cache-ből a régi assetet szolgálta (`afedb76c...`)
+- ebből következően a szerveroldali hotfix kint van, de a kliensoldali látható hatás külön CDN purge vagy verzióbump nélkül nem garantálható azonnal
+
+## Cache-bypass lezárás
+- külön follow-up körben az `impactshop-ads-watch.php` asset verziója `2.5.65` → `2.5.66` értékre emelve
+- cél: új `impactshop-ads-watch.js?ver=2.5.66` URL generálása, hogy a beragadt Cloudflare cache megkerülhető legyen purge nélkül is
+- lokális PHP backup:
+  - `.codex/backups/20260419-ads-watch-version-bump/impactshop-ads-watch.php.pre`
+- távoli PHP backupok:
+  - `/home/sharityh/app/.codex-hotfix-backups/20260419-ads-watch-version-bump/impactshop-ads-watch.php.20260419-160708.pre`
+  - `/home/sharityh/app-staging/.codex-hotfix-backups/20260419-ads-watch-version-bump/impactshop-ads-watch.php.20260419-160708.pre`
+- verifikáció:
+  - publikus HTML már az új assetet hivatkozza: `impactshop-ads-watch.js?ver=2.5.66`
+  - publikus header: `X-ImpactShop-AdsWatch-Version: 2.5.66`
+  - publikus JS hash: `3cd313f32a253cff5226a8322a971d7f529bba999cf3b698af22a88da48a614b`
+  - `impact-challenge-ui-smoke.sh` továbbra is OK

--- a/notes.md
+++ b/notes.md
@@ -1,3 +1,27 @@
+## 2026-04-19 16:08 CEST - ads-watch cache-bypass verzióbump lezárva
+- Az `impactshop-ads-watch.php` asset verzió `2.5.65` → `2.5.66` lett, hogy új JS URL keletkezzen purge nélkül.
+- A PHP deploy backup + rollback mellett kiment mindkét érintett példányra:
+  - `/home/sharityh/app/wp-content/mu-plugins/impactshop-ads-watch.php`
+  - `/home/sharityh/app-staging/wp-content/mu-plugins/impactshop-ads-watch.php`
+- Publikus ellenőrzés:
+  - `X-ImpactShop-AdsWatch-Version: 2.5.66`
+  - HTML script URL: `impactshop-ads-watch.js?ver=2.5.66`
+  - publikus JS hash: `3cd313f32a253cff5226a8322a971d7f529bba999cf3b698af22a88da48a614b`
+- `impact-challenge-ui-smoke.sh` zöld maradt, a cache-bypass lezárás sikeres.
+
+## 2026-04-19 15:35 CEST - ads-watch mobile resize hotfix + deploy-path drift
+- Szűk incidens-hotfix készült az `impactshop-ads-watch.js` mobil resize ágára: hidden-doc guard, tiny-delta skip, burst throttle.
+- Protected change record: `docs/protected-change-records/2026-04-19-ads-watch-mobile-resize-throttle-hotfix.md`.
+- A deploy kivizsgálás közben kiderült, hogy a publikus `app.sharity.hu` JS hash nem az `/home/sharityh/app`, hanem az `/home/sharityh/app-staging` példánnyal egyezett.
+- Emiatt a hotfix backup + rollback mellett mindkét pathra kiment: `app` és `app-staging`.
+- Health endpoint és `impact-challenge-ui-smoke.sh` zöld maradt.
+- A publikus asset a frissítés után is Cloudflare `HIT` cache-ből a régi `2.5.65` tartalmat szolgálta, ezért a kliensoldali látható hatás purge vagy verzióbump nélkül nem garantált azonnal.
+
+## 2026-04-19 15:35:17 CEST - impactall auto log
+- **Result:** stale/no-fresh-run
+- **Megjegyzés:** kézi `~/bin/impactall` újrafuttatás indult, de nem írt friss `impactall-last-run.json` állapotot; a legutóbbi ismert snapshot továbbra is `2026-04-17 07:20:24 CEST`, `warn` (warnings=2, errors=0, duration=4s).
+- **Source:** /Users/bujdosoarnold/Developer/GitHub/.codex/logs/impactall-last-run.json
+
 ## 2026-04-14 15:50 CET - PR103 review-fix: sandbox trust tightening
 - `impactshop_ads_watch_get_request_write_mode()` mostantól csak admin+nonce kérésnél enged sandbox módot.
 - `write_mode` query param fallback kivezetve (header-only control).

--- a/notes.md
+++ b/notes.md
@@ -1,3 +1,8 @@
+## 2026-04-20 07:00 CEST - ads-watch review-fix: trailing resize after burst
+- PR review visszajelzés alapján a mobil resize throttle most már trailing futást is ütemez, így a burst végén érkező végső konténerméret is átmegy az IMA resize felé.
+- A kapcsolódó postmortem addendum szövegében javítva lett az `eldobj` elírás.
+- Ellenőrzés: `node --check wp-content/mu-plugins/impactshop-ads-watch.js` OK, `impact-challenge-ui-smoke.sh` OK.
+
 ## 2026-04-19 16:08 CEST - ads-watch cache-bypass verzióbump lezárva
 - Az `impactshop-ads-watch.php` asset verzió `2.5.65` → `2.5.66` lett, hogy új JS URL keletkezzen purge nélkül.
 - A PHP deploy backup + rollback mellett kiment mindkét érintett példányra:

--- a/system-status-snapshot.md
+++ b/system-status-snapshot.md
@@ -9,6 +9,11 @@
 - `impact-challenge-ui-smoke.sh` továbbra is zöld.
 - Külön audit finding rögzítve: a dokumentált production deploy path és a ténylegesen kiszolgált live asset út között drift gyanú áll fenn.
 
+## 2026-04-20T07:00:00+0200 - ads-watch review-fix: trailing resize after burst
+- Review-fix kör: a leading-edge throttle mellé trailing IMA resize futás került, hogy a mobil resize burst utolsó konténermérete se vesszen el.
+- A kapcsolódó postmortem follow-up szövegben javítva lett az `eldobj` → `eldob` elírás.
+- Gyors verifikáció: `node --check` OK, `impact-challenge-ui-smoke.sh` OK.
+
 ## 2026-04-17T09:45:00+0200 - analytics guard stabilization: routes + skip telemetry + audit range fix
 - Added signed analytics canary routes in MU runtime: `/wp-json/impact/v1/analytics/summary` and `/wp-json/impact/v1/analytics/flags`.
 - Added SKIP telemetry log (`.codex/logs/analytics-skip-events.log`) and 24h WARN threshold in `scripts/verify/analytics-suite.sh`.

--- a/system-status-snapshot.md
+++ b/system-status-snapshot.md
@@ -1,3 +1,14 @@
+## 2026-04-20T06:45:00+0200 - ads-watch mobile resize hotfix canonicalized + cache-bypass closed
+- A 2026-04-19-es mobil-freeze incidens resize hotfixe most már repo truthként is rögzítve van.
+- `impactshop-ads-watch.js`: IMA resize throttle + hidden-doc guard + tiny-delta skip.
+- `impactshop-ads-watch.php`: asset verzió bump `2.5.65 -> 2.5.66`, hogy az új JS URL megkerülje a beragadt CDN cache-t.
+- Publikus verifikáció megtörtént:
+  - `X-ImpactShop-AdsWatch-Version: 2.5.66`
+  - `impactshop-ads-watch.js?ver=2.5.66`
+  - publikus JS hash: `3cd313f32a253cff5226a8322a971d7f529bba999cf3b698af22a88da48a614b`
+- `impact-challenge-ui-smoke.sh` továbbra is zöld.
+- Külön audit finding rögzítve: a dokumentált production deploy path és a ténylegesen kiszolgált live asset út között drift gyanú áll fenn.
+
 ## 2026-04-17T09:45:00+0200 - analytics guard stabilization: routes + skip telemetry + audit range fix
 - Added signed analytics canary routes in MU runtime: `/wp-json/impact/v1/analytics/summary` and `/wp-json/impact/v1/analytics/flags`.
 - Added SKIP telemetry log (`.codex/logs/analytics-skip-events.log`) and 24h WARN threshold in `scripts/verify/analytics-suite.sh`.

--- a/wp-content/mu-plugins/impactshop-ads-watch.js
+++ b/wp-content/mu-plugins/impactshop-ads-watch.js
@@ -105,6 +105,9 @@
         imaProgressFrameId: null,
         imaAdDuration: 0,
         imaClickThroughUrl: '',
+        lastImaResizeAt: 0,
+        lastImaResizeWidth: 0,
+        lastImaResizeHeight: 0,
         adLoadTimeout: null,
         adRequestPending: false,
         adRequestStartTime: 0,
@@ -4062,9 +4065,31 @@
         if (state.adsManager && state.isPlaying && (state.currentMode === 'regular' || state.currentMode === 'sponsor')) {
             try {
                 const container = document.getElementById('video-container');
-                if (container && container.clientWidth > 0 && container.clientHeight > 0) {
-                    state.adsManager.resize(container.clientWidth, container.clientHeight, google.ima.ViewMode.NORMAL);
+                if (document.hidden || !container || container.clientWidth <= 0 || container.clientHeight <= 0) {
+                    return;
                 }
+
+                const width = Math.round(container.clientWidth);
+                const height = Math.round(container.clientHeight);
+                const now = Date.now();
+                const deltaWidth = Math.abs(width - Number(state.lastImaResizeWidth || 0));
+                const deltaHeight = Math.abs(height - Number(state.lastImaResizeHeight || 0));
+
+                // Mobile browsers emit resize bursts while browser chrome or
+                // overlays animate. Ignore tiny or duplicate size changes.
+                if (deltaWidth < 8 && deltaHeight < 8) {
+                    return;
+                }
+
+                // Avoid hammering IMA with repeated resize calls in the same burst.
+                if (now - Number(state.lastImaResizeAt || 0) < 200) {
+                    return;
+                }
+
+                state.lastImaResizeAt = now;
+                state.lastImaResizeWidth = width;
+                state.lastImaResizeHeight = height;
+                state.adsManager.resize(width, height, google.ima.ViewMode.NORMAL);
             } catch (e) {
                 // Ignore resize errors
             }

--- a/wp-content/mu-plugins/impactshop-ads-watch.js
+++ b/wp-content/mu-plugins/impactshop-ads-watch.js
@@ -108,6 +108,9 @@
         lastImaResizeAt: 0,
         lastImaResizeWidth: 0,
         lastImaResizeHeight: 0,
+        pendingImaResizeWidth: 0,
+        pendingImaResizeHeight: 0,
+        pendingImaResizeTimer: null,
         adLoadTimeout: null,
         adRequestPending: false,
         adRequestStartTime: 0,
@@ -4083,12 +4086,37 @@
 
                 // Avoid hammering IMA with repeated resize calls in the same burst.
                 if (now - Number(state.lastImaResizeAt || 0) < 200) {
+                    state.pendingImaResizeWidth = width;
+                    state.pendingImaResizeHeight = height;
+                    if (state.pendingImaResizeTimer) {
+                        clearTimeout(state.pendingImaResizeTimer);
+                    }
+                    state.pendingImaResizeTimer = window.setTimeout(function () {
+                        state.pendingImaResizeTimer = null;
+                        if (!state.adsManager || !state.isPlaying || (state.currentMode !== 'regular' && state.currentMode !== 'sponsor')) {
+                            return;
+                        }
+                        if (document.hidden) {
+                            return;
+                        }
+                        var finalWidth = Math.round(Number(state.pendingImaResizeWidth || 0));
+                        var finalHeight = Math.round(Number(state.pendingImaResizeHeight || 0));
+                        if (finalWidth <= 0 || finalHeight <= 0) {
+                            return;
+                        }
+                        state.lastImaResizeAt = Date.now();
+                        state.lastImaResizeWidth = finalWidth;
+                        state.lastImaResizeHeight = finalHeight;
+                        state.adsManager.resize(finalWidth, finalHeight, google.ima.ViewMode.NORMAL);
+                    }, 220);
                     return;
                 }
 
                 state.lastImaResizeAt = now;
                 state.lastImaResizeWidth = width;
                 state.lastImaResizeHeight = height;
+                state.pendingImaResizeWidth = width;
+                state.pendingImaResizeHeight = height;
                 state.adsManager.resize(width, height, google.ima.ViewMode.NORMAL);
             } catch (e) {
                 // Ignore resize errors

--- a/wp-content/mu-plugins/impactshop-ads-watch.php
+++ b/wp-content/mu-plugins/impactshop-ads-watch.php
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
 // CONSTANTS
 // ─────────────────────────────────────────────────────────────────────────────
 
-define('IMPACTSHOP_ADS_WATCH_VERSION', '2.5.65');
+define('IMPACTSHOP_ADS_WATCH_VERSION', '2.5.66');
 define('IMPACTSHOP_ADS_WATCH_SCHEMA_VERSION', '9');
 define('IMPACTSHOP_ADS_DONATION_POOL', 500000); // Ft
 


### PR DESCRIPTION
## Summary
- canonicalize the 2026-04-19 ads-watch mobile resize incident hotfix in repo history
- preserve the protected change record, rollback evidence, notes, and postmortem continuity for what was actually deployed live
- record the production deploy-path drift and the guard deploy-path follow-up as explicit audited docs

## What Changed
- throttle and guard `adsManager.resize(...)` calls in `wp-content/mu-plugins/impactshop-ads-watch.js`
- bump `IMPACTSHOP_ADS_WATCH_VERSION` from `2.5.65` to `2.5.66` in `wp-content/mu-plugins/impactshop-ads-watch.php` for cache bypass
- add the protected change record for the hotfix and rollback evidence
- add a postmortem follow-up note for the resize incident and deploy/cache drift
- add a production deploy-path audit doc
- add a guard deploy-path fix follow-up doc
- refresh `system-status-snapshot.md` so guarded push continuity stays intact

## Live Verification Already Performed
- public header returned `X-ImpactShop-AdsWatch-Version: 2.5.66`
- public HTML referenced `impactshop-ads-watch.js?ver=2.5.66`
- public JS hash matched the deployed asset:
  - `3cd313f32a253cff5226a8322a971d7f529bba999cf3b698af22a88da48a614b`
- `bash scripts/impact-challenge-ui-smoke.sh https://app.sharity.hu/impact-challenge/` stayed green

## Findings Captured In This PR
- the documented production deploy path and the live-served asset path were not cleanly aligned during the incident
- the hotfix had to be restored to both `/home/sharityh/app` and `/home/sharityh/app-staging` before cache bypass was finalized
- this branch documents that drift explicitly so the canonical guard deploy path can be repaired next

## Guard / Protected Notes
- protected change record:
  - `docs/protected-change-records/2026-04-19-ads-watch-mobile-resize-throttle-hotfix.md`
- rollback evidence and smoke scope are documented there
- follow-up guard fix doc:
  - `docs/impactshop-guard-deploy-path-fix-followup-2026-04-20.md`

## PR Exit Checklist (Required)
- [x] 1. Work was done on dedicated branch/worktree (not `main`)
- [x] 2. Relevant build/tests ran and are green
- [x] 3. `safe-repo-audit.sh --strict --mode push` is green
- [x] 4. `system-status-snapshot.md` updated for module change
- [x] 5. At least one `docs/*.md` updated for module change
- [x] 6. `notes.md` or `conversation-summaries/*` updated (notes-context repos)
- [x] 7. `docs/bastion-guard-status.md` updated when new module file was added
- [x] 8. Deploy guard + smoke checks are logged (if deploy happened)
- [x] 9. Backup/rollback path is recorded
- [x] 10. PR description includes scope, risk, validation, deploy/rollback notes
