### PR TITLE
fix: close deploy-path audit and align guard origin

### DIFF
--- a/bin/deploy-wpcontent-map.sh
+++ b/bin/deploy-wpcontent-map.sh
@@ -57,6 +57,37 @@ run_hatas_korok_post_deploy_smoke() {
   fi
 }
 
+verify_production_origin_alignment() {
+  [[ $IS_STAGING -eq 0 ]] || return 0
+  [[ "${REMOTE_WP_PATH:-}" == "/home/sharityh/app" ]] || return 0
+
+  local remote_check=""
+  remote_check="$(ssh -o BatchMode=yes "$SSH_HOST" "python3 - <<'PY'
+from pathlib import Path
+public_index = Path('/home/sharityh/public_html/index.php')
+app_index = Path('/home/sharityh/app/index.php')
+if not public_index.exists() or not app_index.exists():
+    print('missing')
+    raise SystemExit(0)
+txt = public_index.read_text(encoding='utf-8', errors='ignore')
+print('ok' if '../app/wp-blog-header.php' in txt else 'mismatch')
+PY" < /dev/null)"
+
+  case "$remote_check" in
+    ok)
+      echo "✅ Production origin alignment OK: public_html entrypoint -> /home/sharityh/app"
+      ;;
+    missing)
+      echo "❌ Production origin alignment check failed: missing public_html/app index.php" >&2
+      exit 1
+      ;;
+    *)
+      echo "❌ Production origin alignment mismatch: public_html wrapper does not point to /home/sharityh/app" >&2
+      exit 1
+      ;;
+  esac
+}
+
 if [[ "${DRY_RUN:-0}" == "1" ]]; then
   echo "🛡️ DRY-RUN MODE ENABLED — rsync nem ír a távoli szerverre."
   RSYNC_OPTS="${RSYNC_OPTS:-} -n"
@@ -89,6 +120,7 @@ fi
 echo "🎯 Cél: $SSH_HOST:$REMOTE_WP_CONTENT"
 ssh -o BatchMode=yes "$SSH_HOST" "[ -d '$REMOTE_WP_CONTENT' ] || mkdir -p '$REMOTE_WP_CONTENT'/{plugins,mu-plugins,themes,uploads}" < /dev/null
 verify_remote_bastion_manifest "$(dirname "${REMOTE_WP_CONTENT}")"
+verify_production_origin_alignment
 
 # Szelídített rsync opciók (régi verziókhoz is)
 RSYNC_OPTS_SAFE="${RSYNC_OPTS:-}"

--- a/bin/post-deploy-activate.sh
+++ b/bin/post-deploy-activate.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Állítsd be:
 STAGING_WP_PATH="/home/sharityh/app-staging"
-PROD_WP_PATH="/home/sharityh/public_html"
+PROD_WP_PATH="/home/sharityh/app"
 
 PLUGINS=(
   "impact-bridge-local"

--- a/docs/impactshop-deploy.md
+++ b/docs/impactshop-deploy.md
@@ -32,6 +32,8 @@ Biztonságos, ismételhető staging + production deploy a bástyavédelem mellet
 - Production env: `.deploy.production.env`
 - Guard wrapper: `bin/impactshop-guard-deploy.sh`
 - Mapping deploy: `bin/deploy-wpcontent-map.sh`
+- Production runtime truth: `/home/sharityh/app`
+- Public entry wrapper: `/home/sharityh/public_html/index.php` → `../app/wp-blog-header.php`
 
 ## Staging deploy (guard + mapping)
 ```bash
@@ -63,6 +65,7 @@ bin/impactshop-guard-rollback.sh deploy-YYYYMMDD-HHMMSS
 
 ## Megjegyzések
 - SSH host/user a `.deploy.*.env` fájlokban. A távoli parancsoknál szükség esetén `ssh -t` használható.
+- `public_html` productionön entry wrapper, nem a kanonikus WP runtime gyökér; a guard/deploy path igazsága az `/home/sharityh/app`.
 - Preflight figyelmeztetés (pl. `totals` lassú) deploy-t nem blokkol, de érdemes monitorozni.
 - MP4/asset fájlok ne kerüljenek deployba, ha nem része a mappingnek.
 - Kézi utóellenőrzéshez továbbra is használható: `bin/post-deploy-checklist.sh`, ami már tartalmazza a Hatás Körök smoke-ot is.

--- a/docs/impactshop-guard-deploy-path-fix-followup-2026-04-20.md
+++ b/docs/impactshop-guard-deploy-path-fix-followup-2026-04-20.md
@@ -10,19 +10,26 @@ A guard deploy infrastruktúrát össze kell igazítani a tényleges production 
 - A 2026-04-19-es incidens során a publikus asset-egyezés alapján az `/home/sharityh/app-staging` is érintettnek bizonyult
 - Ez sérti a `Guard scope and source of truth` és a `Canonical guard workflow path` elvet
 
+## Audit eredmény
+
+- A kanonikus production runtime path megerősítve: `/home/sharityh/app`
+- A publikus `public_html/index.php` wrapper innen tölti a WordPress runtime-ot:
+  - `../app/wp-blog-header.php`
+- Ennek megfelelően a production deploy env alapiránya helyes volt; a nyitott rés valójában az volt, hogy ez a wrapper-kapcsolat nem volt explicit guardolt/runbookolt tényként rögzítve
+
 ## Kötelező korrekciók
 
 1. `.deploy.production.env`
-- ellenőrizni kell, hogy a benne lévő `REMOTE_WP_PATH` a tényleges production originre mutat-e
+- lezárt: a benne lévő `REMOTE_WP_PATH=/home/sharityh/app` a tényleges production originre mutat
 
 2. `docs/impactshop-deploy.md`
-- a runbook csak a valós, auditált deploy pathot nevezheti ki production truth-nak
+- frissítve kell kimondania, hogy a production truth az `/home/sharityh/app`, míg `public_html` csak entry wrapper
 
 3. `bin/impactshop-guard-deploy.sh`
 - ellenőrizni kell, hogy ugyanazt a pathot használja, mint a dokumentáció és a live site
 
 4. `bin/deploy-wpcontent-map.sh`
-- production mapping során explicit ellenőrzés kell a tényleges célpathra
+- production mapping során explicit ellenőrzés kell arra, hogy a `public_html` wrapper valóban az `/home/sharityh/app` runtime-ra mutat
 
 5. post-deploy verifikáció
 - az ellenőrzésnek nem elég a HTML route vagy health endpoint

--- a/docs/impactshop-production-deploy-path-audit-2026-04-20.md
+++ b/docs/impactshop-production-deploy-path-audit-2026-04-20.md
@@ -30,17 +30,23 @@
 
 ## Következtetés
 
-A production deploy út jelenleg nincs elég szorosan összezárva a ténylegesen kiszolgált origin/docroot valósággal. A guard deploy runbook és a valós live asset útvonal között legalább egy történeti vagy vhost szintű drift létezik.
+Az audit alapján a kanonikus production WordPress runtime gyökér **`/home/sharityh/app`**.
+
+- A publikus belépési pont **`/home/sharityh/public_html/index.php`**, de ez csak wrapper:
+  - `require __DIR__ . '/../app/wp-blog-header.php';`
+- Ez azt jelenti, hogy a deploy/runbook truth helyesen az `.deploy.production.env` szerinti `/home/sharityh/app`.
+- Az incidens közbeni `app-staging` asset-egyezés nem source-of-truth, hanem környezeti drift/cache parity jel volt.
+- A guard deploy irányt tehát nem átírni kell `app-staging`-re, hanem expliciten rögzíteni, hogy productionön a `public_html` csak entry wrapper, a valódi origin pedig az `app`.
 
 ## Nyitott kérdések
 
-1. Az `app.sharity.hu` tényleges document rootja mi?
-2. Az `/home/sharityh/app-staging` miért tudott egyezni a publikus assettel productionön?
-3. Van-e olyan vhost/symlink/release mapping, amit a `.deploy.production.env` jelenleg nem ír le?
-4. A JS és a PHP miért ugyanabba a drift-mintába futott bele?
+1. Mi okozta pontosan az `app-staging` asset-egyezést az incidens időablakában?
+2. Cache parity, kézi restore vagy történeti fájlszinkron állt mögötte?
+3. Van-e olyan vhost/rewrite vagy operátori útvonal, amely production incidensnél még mindig két pathot érinthet?
 
-## Döntési javaslat
+## Döntés
 
-- A kanonikus production source of truth-ot külön audit eredménnyel ki kell mondani.
-- Addig a mostani incidens-hotfixet érvényes, de nem teljesen kanonikus restore-nak kell tekinteni.
-- A guard deploy infrastruktúrát csak az audit lezárása után szabad átállítani.
+- A production source of truth kimondva: `/home/sharityh/app`
+- A `public_html` szerepe: entry wrapper, nem deploy target
+- A guard deploy infrastruktúrát ehhez kell igazítani és ezzel kell ellenőrizni
+- Az `app-staging` production-egyezést külön drift-megfigyelésként kell kezelni, nem kanonikus célpathként

--- a/docs/protected-change-records/2026-04-20-deploy-path-origin-alignment.md
+++ b/docs/protected-change-records/2026-04-20-deploy-path-origin-alignment.md
@@ -1,0 +1,41 @@
+## Összefoglaló
+- a 2026-04-19 ads-watch incidens utókövetéseként lezárjuk a production deploy-path auditot
+- kimondjuk a kanonikus production runtime truth-ot: `/home/sharityh/app`
+- a deploy tooling explicit ellenőrzést kap arra, hogy `public_html` csak entry wrapper és valóban az `app` runtime-ra mutat
+
+## Protected files touched
+- `bin/deploy-wpcontent-map.sh`
+- `docs/impactshop-deploy.md`
+
+## Touched files
+- `bin/post-deploy-activate.sh`
+- `docs/impactshop-production-deploy-path-audit-2026-04-20.md`
+- `docs/impactshop-guard-deploy-path-fix-followup-2026-04-20.md`
+- `notes.md`
+- `system-status-snapshot.md`
+
+## Kockázat
+- alacsony-közepes
+- a módosítás nem a live runtime viselkedését, hanem a deploy/origin ellenőrzési réteget pontosítja
+- fő kockázat: túl szigorú origin-check megakaszthat production mapping deployt, ha a wrapper struktúra változik
+
+## Rollback
+- git rollback a follow-up branchen vagy revert a merge commitra
+- ha az új origin-check tévesen blokkol deployt, ideiglenesen visszaállítható a korábbi `bin/deploy-wpcontent-map.sh`
+- operatív rollback smoke:
+  - `bash -n bin/deploy-wpcontent-map.sh`
+  - `bash -n bin/post-deploy-activate.sh`
+
+## Smoke scope
+- `route:impact-challenge`
+- `flow:video-start`
+- `browser:chrome`
+- `browser:webkit`
+- `route:impactshop`
+- `flow:go-deal`
+
+## Ellenőrzés
+- távoli bizonyíték: `/home/sharityh/public_html/index.php` ténylegesen `../app/wp-blog-header.php`-ra mutat
+- `.deploy.production.env` továbbra is `/home/sharityh/app` runtime truth-ot nevez meg
+- `bash -n` zöld a módosított deploy scriptekre
+- publikus HTML és header továbbra is `2.5.66` ads-watch runtime-ot mutat

--- a/notes.md
+++ b/notes.md
@@ -1,3 +1,10 @@
+## 2026-04-20 08:30 CEST - deploy-path audit lezárva + guard origin check
+- A production deploy-path audit lezárása alapján a kanonikus production runtime továbbra is `/home/sharityh/app`.
+- A `public_html/index.php` csak entry wrapper, amely az `../app/wp-blog-header.php` runtime-ra mutat.
+- `bin/deploy-wpcontent-map.sh` kapott explicit production-origin alignment ellenőrzést erre a wrapper kapcsolatra.
+- `bin/post-deploy-activate.sh` production pathja javítva lett `/home/sharityh/app` értékre.
+- Az audit és a guard follow-up dokumentumok most már lezáró következtetéssel ezt a production truth-ot rögzítik.
+
 ## 2026-04-20 07:00 CEST - ads-watch review-fix: trailing resize after burst
 - PR review visszajelzés alapján a mobil resize throttle most már trailing futást is ütemez, így a burst végén érkező végső konténerméret is átmegy az IMA resize felé.
 - A kapcsolódó postmortem addendum szövegében javítva lett az `eldobj` elírás.

--- a/system-status-snapshot.md
+++ b/system-status-snapshot.md
@@ -9,6 +9,13 @@
 - `impact-challenge-ui-smoke.sh` továbbra is zöld.
 - Külön audit finding rögzítve: a dokumentált production deploy path és a ténylegesen kiszolgált live asset út között drift gyanú áll fenn.
 
+## 2026-04-20T08:30:00+0200 - production deploy-path audit closed for ads-watch incident follow-up
+- Audit bizonyította, hogy a kanonikus production WordPress runtime gyökér továbbra is `/home/sharityh/app`.
+- A publikus belépési pont `public_html/index.php`, de ez csak wrapper, amely az `../app/wp-blog-header.php` runtime-ra mutat.
+- `bin/deploy-wpcontent-map.sh` most már explicit production-origin alignment ellenőrzést futtat erre a wrapper-kapcsolatra.
+- `bin/post-deploy-activate.sh` production pathja korrigálva lett `/home/sharityh/app` értékre.
+- A runbook és az audit/follow-up docs most már ugyanazt a production truth-ot nevezik meg.
+
 ## 2026-04-20T07:00:00+0200 - ads-watch review-fix: trailing resize after burst
 - Review-fix kör: a leading-edge throttle mellé trailing IMA resize futás került, hogy a mobil resize burst utolsó konténermérete se vesszen el.
 - A kapcsolódó postmortem follow-up szövegben javítva lett az `eldobj` → `eldob` elírás.


### PR DESCRIPTION
## Summary
- close the production deploy-path audit opened during the 2026-04-19 ads-watch incident
- confirm `/home/sharityh/app` as the canonical production WordPress runtime
- align the guarded deploy tooling and docs with the fact that `public_html` is only an entry wrapper

## What Changed
- add an explicit production-origin alignment check to `bin/deploy-wpcontent-map.sh`
- correct `bin/post-deploy-activate.sh` production path to `/home/sharityh/app`
- update `docs/impactshop-deploy.md` to state the canonical production runtime and wrapper relationship
- close the audit and guard follow-up docs with the verified conclusion
- record notes and system-status continuity for the follow-up
- add a protected change record for this deploy-path alignment work

## Verification
- remote audit proved that `/home/sharityh/public_html/index.php` requires `../app/wp-blog-header.php`
- `.deploy.production.env` already points at `/home/sharityh/app`
- `bash -n bin/deploy-wpcontent-map.sh` OK
- `bash -n bin/post-deploy-activate.sh` OK
- live HTML still references `impactshop-ads-watch.js?ver=2.5.66`
- live header still returns `X-ImpactShop-AdsWatch-Version: 2.5.66`

## Risk
- low to medium
- main behavioral change is stricter production-origin verification before mapping deploys
- if the wrapper path changes in the future, the new guard check will block deploy until docs/env are updated

## Rollback
- revert commits from this branch
- or temporarily revert the new origin-alignment check in `bin/deploy-wpcontent-map.sh` if it blocks a valid emergency deploy

## PR Exit Checklist (Required)
- [x] 1. Work was done on dedicated branch/worktree (not `main`)
- [x] 2. Relevant build/tests ran and are green
- [x] 3. `safe-repo-audit.sh --strict --mode push` is green
- [x] 4. `system-status-snapshot.md` updated for module change
- [x] 5. At least one `docs/*.md` updated for module change
- [x] 6. `notes.md` or `conversation-summaries/*` updated (notes-context repos)
- [x] 7. `docs/bastion-guard-status.md` updated when new module file was added
- [x] 8. Deploy guard + smoke checks are logged (if deploy happened)
- [x] 9. Backup/rollback path is recorded
- [x] 10. PR description includes scope, risk, validation, deploy/rollback notes
