### PR TITLE
hardening: canonical impact-community source guard + intl rollback lane safety

### DIFF
--- a/.github/workflows/impact-community-source-guard.yml
+++ b/.github/workflows/impact-community-source-guard.yml
@@ -56,8 +56,9 @@ jobs:
           fi
 
           CANONICAL="$(pwd)/wp-content/mu-plugins/impact-community.php"
-          MUTATED="$(mktemp /tmp/impact-community-mutated-XXXXXX.php)"
-          trap 'rm -f "$MUTATED"' EXIT
+          MUTATED_DIR="$(mktemp -d /tmp/impact-community-mutated-XXXXXX)"
+          MUTATED="$MUTATED_DIR/impact-community.php"
+          trap 'rm -rf "$MUTATED_DIR"' EXIT
           cp "$CANONICAL" "$MUTATED"
           printf '\n// ci mutation\n' >> "$MUTATED"
 

--- a/.github/workflows/impact-community-source-guard.yml
+++ b/.github/workflows/impact-community-source-guard.yml
@@ -14,7 +14,36 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Enforce canonical source guard in deploy script
+      - name: Validate canonical file passes guard locally
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          SCRIPT="scripts/guarded-remote-write.sh"
+          CANONICAL="$(pwd)/wp-content/mu-plugins/impact-community.php"
+          REMOTE_LINES="$(wc -l < "$CANONICAL")"
+
+          chmod +x "$SCRIPT"
+          CANONICAL_IMPACT_COMMUNITY_SOURCE="$CANONICAL" \
+          REMOTE_LINES_OVERRIDE="$REMOTE_LINES" \
+          VALIDATE_ONLY=1 \
+          "$SCRIPT" "$CANONICAL"
+
+      - name: Validate anti-shrink override is honored
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          SCRIPT="scripts/guarded-remote-write.sh"
+          TMP_FILE="$(mktemp /tmp/guarded-write-XXXXXX.php)"
+          trap 'rm -f "$TMP_FILE"' EXIT
+          printf '%s\n' '<?php' 'echo "ok";' > "$TMP_FILE"
+
+          REMOTE_LINES_OVERRIDE=1000 \
+          VALIDATE_ONLY=1 \
+          "$SCRIPT" "$TMP_FILE" --allow-shrink
+
+      - name: Validate non-canonical file is rejected
         shell: bash
         run: |
           set -euo pipefail
@@ -25,10 +54,15 @@ jobs:
             exit 1
           fi
 
-          # Canonical source path and hash checks must remain present.
-          grep -q 'CANONICAL_IMPACT_COMMUNITY_SOURCE' "$SCRIPT"
-          grep -q 'ALLOW_NONCANONICAL_COMMUNITY_SOURCE' "$SCRIPT"
-          grep -q 'Non-canonical impact-community deploy source detected' "$SCRIPT"
-          grep -q 'canonical sha256' "$SCRIPT"
+          CANONICAL="$(pwd)/wp-content/mu-plugins/impact-community.php"
+          MUTATED="$(mktemp /tmp/impact-community-mutated-XXXXXX.php)"
+          trap 'rm -f "$MUTATED"' EXIT
+          cp "$CANONICAL" "$MUTATED"
+          printf '\n// ci mutation\n' >> "$MUTATED"
 
-          echo "✅ Canonical impact-community source/hash guard present."
+          if CANONICAL_IMPACT_COMMUNITY_SOURCE="$CANONICAL" VALIDATE_ONLY=1 "$SCRIPT" "$MUTATED"; then
+            echo "❌ Non-canonical file unexpectedly passed guard." >&2
+            exit 1
+          fi
+
+          echo "✅ Local/CI guard parity verified." 

--- a/.github/workflows/impact-community-source-guard.yml
+++ b/.github/workflows/impact-community-source-guard.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   canonical-source-guard:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -60,7 +61,7 @@ jobs:
           cp "$CANONICAL" "$MUTATED"
           printf '\n// ci mutation\n' >> "$MUTATED"
 
-          if CANONICAL_IMPACT_COMMUNITY_SOURCE="$CANONICAL" VALIDATE_ONLY=1 "$SCRIPT" "$MUTATED"; then
+          if CANONICAL_IMPACT_COMMUNITY_SOURCE="$CANONICAL" REMOTE_LINES_OVERRIDE=1 VALIDATE_ONLY=1 "$SCRIPT" "$MUTATED"; then
             echo "❌ Non-canonical file unexpectedly passed guard." >&2
             exit 1
           fi

--- a/.github/workflows/impact-community-source-guard.yml
+++ b/.github/workflows/impact-community-source-guard.yml
@@ -1,0 +1,34 @@
+name: impact-community-source-guard
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch: {}
+
+jobs:
+  canonical-source-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Enforce canonical source guard in deploy script
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          SCRIPT="scripts/guarded-remote-write.sh"
+          if [[ ! -f "$SCRIPT" ]]; then
+            echo "❌ Missing required deploy guard script: $SCRIPT" >&2
+            exit 1
+          fi
+
+          # Canonical source path and hash checks must remain present.
+          grep -q 'CANONICAL_IMPACT_COMMUNITY_SOURCE' "$SCRIPT"
+          grep -q 'ALLOW_NONCANONICAL_COMMUNITY_SOURCE' "$SCRIPT"
+          grep -q 'Non-canonical impact-community deploy source detected' "$SCRIPT"
+          grep -q 'canonical sha256' "$SCRIPT"
+
+          echo "✅ Canonical impact-community source/hash guard present."

--- a/docs/protected-change-records/2026-05-05-impact-community-source-guard-hardening.md
+++ b/docs/protected-change-records/2026-05-05-impact-community-source-guard-hardening.md
@@ -20,3 +20,8 @@
 
 ## Megjegyzes
 - A hajnali regresszio mintazatahoz igazodva a veletlen nem-kanonikus forrasbol torteno deploy lane immar fail-closed.
+
+## Review-fix update (2026-05-05)
+- `scripts/guarded-remote-write.sh`: a canonical check hash-elsodleges, worktree-kompatibilis; `--allow-shrink` most tenylegesen mukodik.
+- `scripts/impact-intl-runtime-rollback.sh`: hash mismatch / missing file mar fail-closed (nem csendes skip success).
+- `.github/workflows/impact-community-source-guard.yml`: grep helyett futtathato viselkedes parity-check (pass canonical, pass allow-shrink, reject mutated non-canonical).

--- a/docs/protected-change-records/2026-05-05-impact-community-source-guard-hardening.md
+++ b/docs/protected-change-records/2026-05-05-impact-community-source-guard-hardening.md
@@ -1,0 +1,22 @@
+# 2026-05-05 - Impact Community source guard hardening
+
+## Scope
+- Canonical source/hash guard bevezetese a `scripts/guarded-remote-write.sh` scriptben `impact-community.php` deploy elott.
+- `scripts/impact-intl-runtime-backup.sh` es `scripts/impact-intl-runtime-rollback.sh` deduplikalasa.
+- Community file backup/rollback explicit opt-in + explicit acknowledgement moge teve.
+- CI workflow: `.github/workflows/impact-community-source-guard.yml`.
+
+## Kockazat
+- Alacsony: guard script szigoritas es folyamatvedelem, runtime plugin kodot nem modosit.
+
+## Rollback
+- Commit rollback: `git revert 2869ee02` es `git revert 25376e8c`.
+- Operativ rollback: korabbi deploy script lane tovabbra is hasznalhato, community restore csak explicit flaggel.
+
+## Smoke
+- `bash -n scripts/guarded-remote-write.sh scripts/impact-intl-runtime-backup.sh scripts/impact-intl-runtime-rollback.sh`
+- `scripts/impact-intl-runtime-backup.sh --dry-run --backup-id test-intl-guard`
+- `scripts/impact-intl-runtime-backup.sh --dry-run --include-community --backup-id test-intl-guard` (vart fail ack nelkul)
+
+## Megjegyzes
+- A hajnali regresszio mintazatahoz igazodva a veletlen nem-kanonikus forrasbol torteno deploy lane immar fail-closed.

--- a/notes.md
+++ b/notes.md
@@ -6762,3 +6762,9 @@ Saved 43 promotions to /Users/bujdosoarnold/Documents/GitHub/ai-agent/tools/out/
 - Intl lane backup/rollback scriptek deduplikalva (`scripts/impact-intl-runtime-backup.sh`, `scripts/impact-intl-runtime-rollback.sh`).
 - Community file kezeles defaultban tiltott; csak explicit `--include-community --ack-include-community` mellett fut.
 - CI check hozzaadva: `.github/workflows/impact-community-source-guard.yml`.
+
+### 2026-05-05 — PR129 review-fix iteration
+- Javitas: `--allow-shrink` flag tenylegesen mukodik a `guarded-remote-write.sh` anti-shrink gate-ben.
+- Javitas: canonical guard hash alapon elfogadja a worktree pathot is, de nem-kanonikus tartalmat tovabbra is blokkol.
+- Javitas: rollback lane hash mismatch / missing backup file eseten fail-closed.
+- CI parity-check workflow frissitve, mar nem csak marker stringeket keres.

--- a/notes.md
+++ b/notes.md
@@ -6756,3 +6756,9 @@ Saved 43 promotions to /Users/bujdosoarnold/Documents/GitHub/ai-agent/tools/out/
 - Új shortcode: `[impact_event_admin_dashboard campaign="jovonkvize-2026"]`.
 - Új beilleszthető JS: `wp-content/mu-plugins/impactshop-event-admin-dashboard-widget.js`.
 - Lint: `php -l` PASS (donation+auction plugin), `node --check` PASS (dashboard js).
+
+### 2026-05-05 — impact-community source guard hardening
+- Deploy guard: `scripts/guarded-remote-write.sh` most canonical path + sha256 egyezest kovetel `impact-community.php` esetben.
+- Intl lane backup/rollback scriptek deduplikalva (`scripts/impact-intl-runtime-backup.sh`, `scripts/impact-intl-runtime-rollback.sh`).
+- Community file kezeles defaultban tiltott; csak explicit `--include-community --ack-include-community` mellett fut.
+- CI check hozzaadva: `.github/workflows/impact-community-source-guard.yml`.

--- a/scripts/guarded-remote-write.sh
+++ b/scripts/guarded-remote-write.sh
@@ -1,19 +1,54 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Guarded remote write — impact-community.php deploy guard
 # Ellenőrzi: szimbólumok, anti-shrink, backup, rollback
 
-FILE_TO_WRITE="${1:-}"
+FILE_TO_WRITE=""
 REMOTE_HOST="${REMOTE_HOST:-s59.tarhely.com}"
 REMOTE_USER="${REMOTE_USER:-sharityh}"
 REMOTE_APP="${REMOTE_APP:-/home/sharityh/app}"
 ALLOW_SHRINK="${ALLOW_SHRINK:-0}"
 CANONICAL_IMPACT_COMMUNITY_SOURCE="${CANONICAL_IMPACT_COMMUNITY_SOURCE:-/Users/bujdosoarnold/Developer/GitHub/wp-content/mu-plugins/impact-community.php}"
 ALLOW_NONCANONICAL_COMMUNITY_SOURCE="${ALLOW_NONCANONICAL_COMMUNITY_SOURCE:-0}"
+VALIDATE_ONLY="${VALIDATE_ONLY:-0}"
+REMOTE_LINES_OVERRIDE="${REMOTE_LINES_OVERRIDE:-}"
+
+usage() {
+    cat <<'EOF'
+Usage: guarded-remote-write.sh <file_path> [--allow-shrink] [--validate-only]
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --allow-shrink)
+            ALLOW_SHRINK=1
+            shift
+            ;;
+        --validate-only)
+            VALIDATE_ONLY=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            if [[ -z "$FILE_TO_WRITE" ]]; then
+                FILE_TO_WRITE="$1"
+                shift
+            else
+                echo "ERROR: Unknown argument: $1" >&2
+                usage >&2
+                exit 1
+            fi
+            ;;
+    esac
+done
 
 if [ -z "$FILE_TO_WRITE" ]; then
-    echo "Usage: $0 <file_path> [--allow-shrink]"
+    usage >&2
     exit 1
 fi
 
@@ -49,12 +84,12 @@ if [[ "$FILE_TO_WRITE" == *"impact-community.php" ]]; then
         exit 1
     fi
 
-    LOCAL_REALPATH="$(realpath_portable "$FILE_TO_WRITE")"
-    CANONICAL_REALPATH="$(realpath_portable "$CANONICAL_IMPACT_COMMUNITY_SOURCE")"
     LOCAL_HASH="$(sha256_file "$FILE_TO_WRITE")"
     CANONICAL_HASH="$(sha256_file "$CANONICAL_IMPACT_COMMUNITY_SOURCE")"
+    LOCAL_REALPATH="$(realpath_portable "$FILE_TO_WRITE")"
+    CANONICAL_REALPATH="$(realpath_portable "$CANONICAL_IMPACT_COMMUNITY_SOURCE")"
 
-    if [[ "$LOCAL_REALPATH" != "$CANONICAL_REALPATH" || "$LOCAL_HASH" != "$CANONICAL_HASH" ]]; then
+    if [[ "$LOCAL_HASH" != "$CANONICAL_HASH" ]]; then
         echo "FAIL: Non-canonical impact-community deploy source detected."
         echo "  local path:      $LOCAL_REALPATH"
         echo "  canonical path:  $CANONICAL_REALPATH"
@@ -66,7 +101,10 @@ if [[ "$FILE_TO_WRITE" == *"impact-community.php" ]]; then
         fi
         echo "[guard] WARNING: bypassing canonical source guard (ALLOW_NONCANONICAL_COMMUNITY_SOURCE=1)."
     else
-        echo "[guard] Canonical impact-community source verified ✓"
+        echo "[guard] Canonical impact-community source verified by sha256 ✓"
+        if [[ "$LOCAL_REALPATH" != "$CANONICAL_REALPATH" ]]; then
+            echo "[guard] NOTE: alternate worktree path accepted because file hash matches canonical source."
+        fi
     fi
     
     REQUIRED_SYMBOLS=(
@@ -93,25 +131,28 @@ fi
 echo "[guard] Anti-shrink validation..."
 LOCAL_LINES=$(wc -l < "$FILE_TO_WRITE")
 BASENAME=$(basename "$FILE_TO_WRITE")
-REMOTE_LINES=$(ssh "${REMOTE_USER}@${REMOTE_HOST}" "wc -l < ${REMOTE_APP}/wp-content/mu-plugins/${BASENAME}" 2>/dev/null || echo "0")
+if [[ -n "$REMOTE_LINES_OVERRIDE" ]]; then
+    REMOTE_LINES="$REMOTE_LINES_OVERRIDE"
+else
+    REMOTE_LINES=$(ssh "${REMOTE_USER}@${REMOTE_HOST}" "wc -l < ${REMOTE_APP}/wp-content/mu-plugins/${BASENAME}" 2>/dev/null || echo "0")
+fi
 
 if [ "$REMOTE_LINES" -gt 0 ]; then
     MIN_LINES=$((REMOTE_LINES * 90 / 100))
     if [ "$LOCAL_LINES" -lt "$MIN_LINES" ]; then
-        echo "FAIL: Local file shrink detected!"
-        echo "  Local lines:  $LOCAL_LINES"
-        echo "  Remote lines: $REMOTE_LINES (90% threshold: $MIN_LINES)"
-        echo "  Use --allow-shrink with explicit review."
-        exit 1
+        if [[ "$ALLOW_SHRINK" != "1" ]]; then
+            echo "FAIL: Local file shrink detected!"
+            echo "  Local lines:  $LOCAL_LINES"
+            echo "  Remote lines: $REMOTE_LINES (90% threshold: $MIN_LINES)"
+            echo "  Use --allow-shrink with explicit review."
+            exit 1
+        fi
+        echo "[guard] WARNING: anti-shrink bypass enabled (--allow-shrink)."
+        echo "[guard]          local=$LOCAL_LINES remote=$REMOTE_LINES threshold=$MIN_LINES"
+    else
+        echo "[guard] Anti-shrink OK: local=$LOCAL_LINES, remote=$REMOTE_LINES ✓"
     fi
-    echo "[guard] Anti-shrink OK: local=$LOCAL_LINES, remote=$REMOTE_LINES ✓"
 fi
-
-# ========== BACKUP ==========
-echo "[guard] Creating backup..."
-BACKUP_TS=$(date +%Y%m%d-%H%M%S)
-ssh "${REMOTE_USER}@${REMOTE_HOST}" "cp ${REMOTE_APP}/wp-content/mu-plugins/${BASENAME} ${REMOTE_APP}/wp-content/mu-plugins/${BASENAME}.bak-${BACKUP_TS} && chmod 644 ${REMOTE_APP}/wp-content/mu-plugins/${BASENAME}"
-echo "[guard] Backup created: *.bak-$BACKUP_TS ✓"
 
 # ========== SYNTAX CHECK ==========
 echo "[guard] Local syntax validation..."
@@ -119,6 +160,17 @@ if [[ "$FILE_TO_WRITE" == *.php ]]; then
     php -l "$FILE_TO_WRITE" > /dev/null || { echo "FAIL: PHP syntax error"; exit 1; }
     echo "[guard] PHP syntax OK ✓"
 fi
+
+if [[ "$VALIDATE_ONLY" == "1" ]]; then
+    echo "[guard] Validation-only mode: remote backup/deploy skipped."
+    exit 0
+fi
+
+# ========== BACKUP ==========
+echo "[guard] Creating backup..."
+BACKUP_TS=$(date +%Y%m%d-%H%M%S)
+ssh "${REMOTE_USER}@${REMOTE_HOST}" "cp ${REMOTE_APP}/wp-content/mu-plugins/${BASENAME} ${REMOTE_APP}/wp-content/mu-plugins/${BASENAME}.bak-${BACKUP_TS} && chmod 644 ${REMOTE_APP}/wp-content/mu-plugins/${BASENAME}"
+echo "[guard] Backup created: *.bak-$BACKUP_TS ✓"
 
 # ========== DEPLOY ==========
 echo "[guard] Deploying..."

--- a/scripts/guarded-remote-write.sh
+++ b/scripts/guarded-remote-write.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+set -euo pipefail
+
+# Guarded remote write — impact-community.php deploy guard
+# Ellenőrzi: szimbólumok, anti-shrink, backup, rollback
+
+FILE_TO_WRITE="${1:-}"
+REMOTE_HOST="${REMOTE_HOST:-s59.tarhely.com}"
+REMOTE_USER="${REMOTE_USER:-sharityh}"
+REMOTE_APP="${REMOTE_APP:-/home/sharityh/app}"
+ALLOW_SHRINK="${ALLOW_SHRINK:-0}"
+CANONICAL_IMPACT_COMMUNITY_SOURCE="${CANONICAL_IMPACT_COMMUNITY_SOURCE:-/Users/bujdosoarnold/Developer/GitHub/wp-content/mu-plugins/impact-community.php}"
+ALLOW_NONCANONICAL_COMMUNITY_SOURCE="${ALLOW_NONCANONICAL_COMMUNITY_SOURCE:-0}"
+
+if [ -z "$FILE_TO_WRITE" ]; then
+    echo "Usage: $0 <file_path> [--allow-shrink]"
+    exit 1
+fi
+
+if [ ! -f "$FILE_TO_WRITE" ]; then
+    echo "ERROR: File not found: $FILE_TO_WRITE"
+    exit 1
+fi
+
+echo "[guard] Validating: $FILE_TO_WRITE"
+
+realpath_portable() {
+    local path="$1"
+    if [[ ! -e "$path" ]]; then
+        return 1
+    fi
+    local dir base
+    dir="$(cd "$(dirname "$path")" && pwd -P)"
+    base="$(basename "$path")"
+    printf '%s/%s' "$dir" "$base"
+}
+
+sha256_file() {
+    local path="$1"
+    shasum -a 256 "$path" | awk '{print $1}'
+}
+
+# ========== SYMBOL CHECKS — impact-community.php ==========
+if [[ "$FILE_TO_WRITE" == *"impact-community.php" ]]; then
+    echo "[guard] Impact-Community required symbols check..."
+
+    if [[ ! -f "$CANONICAL_IMPACT_COMMUNITY_SOURCE" ]]; then
+        echo "FAIL: Canonical impact-community source not found: $CANONICAL_IMPACT_COMMUNITY_SOURCE"
+        exit 1
+    fi
+
+    LOCAL_REALPATH="$(realpath_portable "$FILE_TO_WRITE")"
+    CANONICAL_REALPATH="$(realpath_portable "$CANONICAL_IMPACT_COMMUNITY_SOURCE")"
+    LOCAL_HASH="$(sha256_file "$FILE_TO_WRITE")"
+    CANONICAL_HASH="$(sha256_file "$CANONICAL_IMPACT_COMMUNITY_SOURCE")"
+
+    if [[ "$LOCAL_REALPATH" != "$CANONICAL_REALPATH" || "$LOCAL_HASH" != "$CANONICAL_HASH" ]]; then
+        echo "FAIL: Non-canonical impact-community deploy source detected."
+        echo "  local path:      $LOCAL_REALPATH"
+        echo "  canonical path:  $CANONICAL_REALPATH"
+        echo "  local sha256:    $LOCAL_HASH"
+        echo "  canonical sha256:$CANONICAL_HASH"
+        if [[ "$ALLOW_NONCANONICAL_COMMUNITY_SOURCE" != "1" ]]; then
+            echo "Set ALLOW_NONCANONICAL_COMMUNITY_SOURCE=1 only for explicit incident-approved deploys."
+            exit 1
+        fi
+        echo "[guard] WARNING: bypassing canonical source guard (ALLOW_NONCANONICAL_COMMUNITY_SOURCE=1)."
+    else
+        echo "[guard] Canonical impact-community source verified ✓"
+    fi
+    
+    REQUIRED_SYMBOLS=(
+        "function ic_maybe_migrate_db"
+        "function ic_seed_ngo_circles"
+        "CREATE TABLE.*ic_circles"
+        "ic_rest_circles_list"
+        "ic_rest_circle_detail"
+        "attached_ngo_ids"
+    )
+    
+    for symbol in "${REQUIRED_SYMBOLS[@]}"; do
+        if ! grep -q "$symbol" "$FILE_TO_WRITE"; then
+            echo "FAIL: Required symbol missing: $symbol"
+            echo "Impact-Community database initialization will fail!"
+            exit 1
+        fi
+    done
+    
+    echo "[guard] All required symbols present ✓"
+fi
+
+# ========== ANTI-SHRINK CHECK ==========
+echo "[guard] Anti-shrink validation..."
+LOCAL_LINES=$(wc -l < "$FILE_TO_WRITE")
+BASENAME=$(basename "$FILE_TO_WRITE")
+REMOTE_LINES=$(ssh "${REMOTE_USER}@${REMOTE_HOST}" "wc -l < ${REMOTE_APP}/wp-content/mu-plugins/${BASENAME}" 2>/dev/null || echo "0")
+
+if [ "$REMOTE_LINES" -gt 0 ]; then
+    MIN_LINES=$((REMOTE_LINES * 90 / 100))
+    if [ "$LOCAL_LINES" -lt "$MIN_LINES" ]; then
+        echo "FAIL: Local file shrink detected!"
+        echo "  Local lines:  $LOCAL_LINES"
+        echo "  Remote lines: $REMOTE_LINES (90% threshold: $MIN_LINES)"
+        echo "  Use --allow-shrink with explicit review."
+        exit 1
+    fi
+    echo "[guard] Anti-shrink OK: local=$LOCAL_LINES, remote=$REMOTE_LINES ✓"
+fi
+
+# ========== BACKUP ==========
+echo "[guard] Creating backup..."
+BACKUP_TS=$(date +%Y%m%d-%H%M%S)
+ssh "${REMOTE_USER}@${REMOTE_HOST}" "cp ${REMOTE_APP}/wp-content/mu-plugins/${BASENAME} ${REMOTE_APP}/wp-content/mu-plugins/${BASENAME}.bak-${BACKUP_TS} && chmod 644 ${REMOTE_APP}/wp-content/mu-plugins/${BASENAME}"
+echo "[guard] Backup created: *.bak-$BACKUP_TS ✓"
+
+# ========== SYNTAX CHECK ==========
+echo "[guard] Local syntax validation..."
+if [[ "$FILE_TO_WRITE" == *.php ]]; then
+    php -l "$FILE_TO_WRITE" > /dev/null || { echo "FAIL: PHP syntax error"; exit 1; }
+    echo "[guard] PHP syntax OK ✓"
+fi
+
+# ========== DEPLOY ==========
+echo "[guard] Deploying..."
+scp "$FILE_TO_WRITE" "${REMOTE_USER}@${REMOTE_HOST}:${REMOTE_APP}/wp-content/mu-plugins/${BASENAME}"
+
+echo "[guard] Remote syntax validation..."
+ssh "${REMOTE_USER}@${REMOTE_HOST}" "php -l ${REMOTE_APP}/wp-content/mu-plugins/${BASENAME} && chmod 444 ${REMOTE_APP}/wp-content/mu-plugins/${BASENAME}"
+
+echo "[guard] Deploy completed successfully ✓"
+ROLLBACK_CMD="ssh ${REMOTE_USER}@${REMOTE_HOST} 'chmod 644 ${REMOTE_APP}/wp-content/mu-plugins/${BASENAME}.bak-${BACKUP_TS} && cp ${REMOTE_APP}/wp-content/mu-plugins/${BASENAME}.bak-${BACKUP_TS} ${REMOTE_APP}/wp-content/mu-plugins/${BASENAME} && chmod 444 ${REMOTE_APP}/wp-content/mu-plugins/${BASENAME}'"
+echo "[guard] To rollback: $ROLLBACK_CMD"

--- a/scripts/impact-intl-runtime-backup.sh
+++ b/scripts/impact-intl-runtime-backup.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BACKUP_BASE="${ROOT_DIR}/.codex/backups/impact-intl-runtime"
+DRY_RUN=0
+INCLUDE_COMMUNITY=0
+ACK_INCLUDE_COMMUNITY=0
+BACKUP_ID="$(date -u +%Y%m%dT%H%M%SZ)"
+
+CORE_FILES=(
+  "wp-content/mu-plugins/impactshop-intl-runtime.php"
+  "wp-content/mu-plugins/impactshop-offerwall-intl-overlay.php"
+  "wp-content/mu-plugins/impactshop-offerwall-intl-overlay.js"
+  "wp-content/mu-plugins/impactshop-offerwall.php"
+  "wp-content/mu-plugins/impactshop-offerwall.js"
+  "wp-content/mu-plugins/impactshop-ads-watch-intl-overlay.php"
+  "wp-content/mu-plugins/impactshop-ads-watch-intl-overlay.js"
+  "wp-content/mu-plugins/impactshop-ads-watch.php"
+  "wp-content/mu-plugins/impactshop-ads-watch.js"
+  "wp-content/mu-plugins/impactshop-ngo-guides.php"
+  "wp-content/mu-plugins/impactshop-ngo-guides/hatas-korok.html"
+  "wp-content/mu-plugins/impactshop-ngo-guides/hatas-korok-en.html"
+)
+
+COMMUNITY_FILES=(
+  "wp-content/mu-plugins/impact-community.php"
+  "wp-content/mu-plugins/impact-community-app.php"
+)
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/impact-intl-runtime-backup.sh [options]
+
+Options:
+  --backup-id ID                Backup identifier (default: UTC timestamp)
+  --dry-run                     Print planned actions only
+  --include-community           Include impact-community files in backup
+  --ack-include-community       Required safety acknowledgement with --include-community
+  -h, --help                    Show help
+
+Note:
+  Community files are excluded by default to prevent accidental rollback lanes
+  from restoring unrelated admin/community backend state.
+EOF
+}
+
+validate_backup_id() {
+  local value="$1"
+  [[ "$value" =~ ^[A-Za-z0-9._-]+$ ]]
+}
+
+is_core_path() {
+  local relative_path="$1"
+  local path
+  for path in "${CORE_FILES[@]}"; do
+    [[ "$relative_path" == "$path" ]] && return 0
+  done
+  return 1
+}
+
+is_community_path() {
+  local relative_path="$1"
+  local path
+  for path in "${COMMUNITY_FILES[@]}"; do
+    [[ "$relative_path" == "$path" ]] && return 0
+  done
+  return 1
+}
+
+is_allowed_relative_path() {
+  local relative_path="$1"
+  if is_core_path "$relative_path"; then
+    return 0
+  fi
+  if [[ "$INCLUDE_COMMUNITY" -eq 1 ]] && is_community_path "$relative_path"; then
+    return 0
+  fi
+  return 1
+}
+
+hash_file() {
+  local file_path="$1"
+  shasum -a 256 "$file_path" | awk '{print $1}'
+}
+
+mkdir_cmd() {
+  local path="$1"
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "[dry-run] mkdir -p $path"
+  else
+    mkdir -p "$path"
+  fi
+}
+
+copy_cmd() {
+  local source="$1"
+  local destination="$2"
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "[dry-run] cp $source $destination"
+  else
+    cp "$source" "$destination"
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    --include-community)
+      INCLUDE_COMMUNITY=1
+      shift
+      ;;
+    --ack-include-community)
+      ACK_INCLUDE_COMMUNITY=1
+      shift
+      ;;
+    --backup-id)
+      BACKUP_ID="${2:?missing backup id}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if ! validate_backup_id "$BACKUP_ID"; then
+  echo "Invalid backup id: ${BACKUP_ID}" >&2
+  exit 1
+fi
+
+if [[ "$INCLUDE_COMMUNITY" -eq 1 && "$ACK_INCLUDE_COMMUNITY" -ne 1 ]]; then
+  echo "Refusing community backup without explicit acknowledgement." >&2
+  echo "Use: --include-community --ack-include-community" >&2
+  exit 1
+fi
+
+TARGET_DIR="${BACKUP_BASE}/${BACKUP_ID}"
+MANIFEST_PATH="${TARGET_DIR}/manifest.txt"
+
+FILES=("${CORE_FILES[@]}")
+if [[ "$INCLUDE_COMMUNITY" -eq 1 ]]; then
+  FILES+=("${COMMUNITY_FILES[@]}")
+fi
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  echo "[dry-run] backup id: ${BACKUP_ID}"
+  echo "[dry-run] target dir: ${TARGET_DIR}"
+fi
+
+mkdir_cmd "$TARGET_DIR"
+
+if [[ "$DRY_RUN" -eq 0 ]]; then
+  {
+    echo "BACKUP_ID=${BACKUP_ID}"
+    echo "CREATED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "INCLUDE_COMMUNITY=${INCLUDE_COMMUNITY}"
+    echo "FILES"
+  } > "$MANIFEST_PATH"
+fi
+
+for relative_path in "${FILES[@]}"; do
+  if ! is_allowed_relative_path "$relative_path"; then
+    echo "skip disallowed path: ${relative_path}" >&2
+    continue
+  fi
+
+  source_path="${ROOT_DIR}/${relative_path}"
+  if [[ ! -f "$source_path" ]]; then
+    echo "skip missing: ${relative_path}"
+    continue
+  fi
+
+  target_path="${TARGET_DIR}/${relative_path}"
+  mkdir_cmd "$(dirname "$target_path")"
+  copy_cmd "$source_path" "$target_path"
+
+  if [[ "$DRY_RUN" -eq 0 ]]; then
+    echo -e "FILE\t$(hash_file "$source_path")\t$relative_path" >> "$MANIFEST_PATH"
+  fi
+done
+
+echo "backup ready: ${TARGET_DIR}"

--- a/scripts/impact-intl-runtime-rollback.sh
+++ b/scripts/impact-intl-runtime-rollback.sh
@@ -143,6 +143,9 @@ fi
 
 TARGET_DIR="${BACKUP_BASE}/${BACKUP_ID}"
 MANIFEST_PATH="${TARGET_DIR}/manifest.txt"
+ATTEMPTED_COUNT=0
+RESTORED_COUNT=0
+FAILURE_COUNT=0
 
 if [[ ! -f "$MANIFEST_PATH" ]]; then
   echo "Manifest not found: ${MANIFEST_PATH}" >&2
@@ -166,7 +169,8 @@ while IFS= read -r line; do
 
   IFS=$'\t' read -r kind expected_hash relative_path <<< "$line"
   if [[ "$kind" != "FILE" || -z "$relative_path" || -z "$expected_hash" ]]; then
-    echo "skip malformed manifest entry" >&2
+    echo "FAIL: malformed manifest entry" >&2
+    FAILURE_COUNT=$((FAILURE_COUNT + 1))
     continue
   fi
 
@@ -180,21 +184,36 @@ while IFS= read -r line; do
     continue
   fi
 
+  ATTEMPTED_COUNT=$((ATTEMPTED_COUNT + 1))
+
   source_path="${TARGET_DIR}/${relative_path}"
   destination_path="${ROOT_DIR}/${relative_path}"
 
   if [[ ! -f "$source_path" ]]; then
-    echo "skip missing backup file: ${relative_path}" >&2
+    echo "FAIL: missing backup file: ${relative_path}" >&2
+    FAILURE_COUNT=$((FAILURE_COUNT + 1))
     continue
   fi
 
   actual_hash="$(hash_file "$source_path")"
   if [[ "$actual_hash" != "$expected_hash" ]]; then
-    echo "skip hash mismatch: ${relative_path}" >&2
+    echo "FAIL: hash mismatch: ${relative_path}" >&2
+    FAILURE_COUNT=$((FAILURE_COUNT + 1))
     continue
   fi
 
   restore_cmd "$source_path" "$destination_path"
+  RESTORED_COUNT=$((RESTORED_COUNT + 1))
 done < "$MANIFEST_PATH"
+
+if [[ "$ATTEMPTED_COUNT" -eq 0 ]]; then
+  echo "FAIL: no restorable files processed from manifest: ${MANIFEST_PATH}" >&2
+  exit 1
+fi
+
+if [[ "$FAILURE_COUNT" -gt 0 ]]; then
+  echo "FAIL: rollback incomplete (${FAILURE_COUNT} failure(s), ${RESTORED_COUNT}/${ATTEMPTED_COUNT} restored)." >&2
+  exit 1
+fi
 
 echo "rollback applied from: ${TARGET_DIR}"

--- a/scripts/impact-intl-runtime-rollback.sh
+++ b/scripts/impact-intl-runtime-rollback.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BACKUP_BASE="${ROOT_DIR}/.codex/backups/impact-intl-runtime"
+DRY_RUN=0
+INCLUDE_COMMUNITY=0
+ACK_INCLUDE_COMMUNITY=0
+BACKUP_ID=""
+
+CORE_FILES=(
+  "wp-content/mu-plugins/impactshop-intl-runtime.php"
+  "wp-content/mu-plugins/impactshop-offerwall-intl-overlay.php"
+  "wp-content/mu-plugins/impactshop-offerwall-intl-overlay.js"
+  "wp-content/mu-plugins/impactshop-offerwall.php"
+  "wp-content/mu-plugins/impactshop-offerwall.js"
+  "wp-content/mu-plugins/impactshop-ads-watch-intl-overlay.php"
+  "wp-content/mu-plugins/impactshop-ads-watch-intl-overlay.js"
+  "wp-content/mu-plugins/impactshop-ads-watch.php"
+  "wp-content/mu-plugins/impactshop-ads-watch.js"
+  "wp-content/mu-plugins/impactshop-ngo-guides.php"
+  "wp-content/mu-plugins/impactshop-ngo-guides/hatas-korok.html"
+  "wp-content/mu-plugins/impactshop-ngo-guides/hatas-korok-en.html"
+)
+
+COMMUNITY_FILES=(
+  "wp-content/mu-plugins/impact-community.php"
+  "wp-content/mu-plugins/impact-community-app.php"
+)
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/impact-intl-runtime-rollback.sh --backup-id ID [options]
+
+Options:
+  --backup-id ID                Backup identifier to restore from (required)
+  --dry-run                     Print planned restore actions only
+  --include-community           Restore impact-community files too
+  --ack-include-community       Required safety acknowledgement with --include-community
+  -h, --help                    Show help
+
+Note:
+  Community files are skipped by default even if they are present in the manifest.
+EOF
+}
+
+validate_backup_id() {
+  local value="$1"
+  [[ "$value" =~ ^[A-Za-z0-9._-]+$ ]]
+}
+
+is_core_path() {
+  local relative_path="$1"
+  local path
+  for path in "${CORE_FILES[@]}"; do
+    [[ "$relative_path" == "$path" ]] && return 0
+  done
+  return 1
+}
+
+is_community_path() {
+  local relative_path="$1"
+  local path
+  for path in "${COMMUNITY_FILES[@]}"; do
+    [[ "$relative_path" == "$path" ]] && return 0
+  done
+  return 1
+}
+
+is_allowed_relative_path() {
+  local relative_path="$1"
+  if is_core_path "$relative_path"; then
+    return 0
+  fi
+  if [[ "$INCLUDE_COMMUNITY" -eq 1 ]] && is_community_path "$relative_path"; then
+    return 0
+  fi
+  return 1
+}
+
+hash_file() {
+  local file_path="$1"
+  shasum -a 256 "$file_path" | awk '{print $1}'
+}
+
+restore_cmd() {
+  local source="$1"
+  local destination="$2"
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "[dry-run] cp $source $destination"
+  else
+    mkdir -p "$(dirname "$destination")"
+    cp "$source" "$destination"
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    --include-community)
+      INCLUDE_COMMUNITY=1
+      shift
+      ;;
+    --ack-include-community)
+      ACK_INCLUDE_COMMUNITY=1
+      shift
+      ;;
+    --backup-id)
+      BACKUP_ID="${2:?missing backup id}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$BACKUP_ID" ]]; then
+  echo "--backup-id is required" >&2
+  usage >&2
+  exit 1
+fi
+
+if ! validate_backup_id "$BACKUP_ID"; then
+  echo "Invalid backup id: ${BACKUP_ID}" >&2
+  exit 1
+fi
+
+if [[ "$INCLUDE_COMMUNITY" -eq 1 && "$ACK_INCLUDE_COMMUNITY" -ne 1 ]]; then
+  echo "Refusing community rollback without explicit acknowledgement." >&2
+  echo "Use: --include-community --ack-include-community" >&2
+  exit 1
+fi
+
+TARGET_DIR="${BACKUP_BASE}/${BACKUP_ID}"
+MANIFEST_PATH="${TARGET_DIR}/manifest.txt"
+
+if [[ ! -f "$MANIFEST_PATH" ]]; then
+  echo "Manifest not found: ${MANIFEST_PATH}" >&2
+  exit 1
+fi
+
+in_files=0
+while IFS= read -r line; do
+  if [[ "$line" == "FILES" ]]; then
+    in_files=1
+    continue
+  fi
+
+  if [[ "$in_files" -eq 0 || -z "$line" ]]; then
+    continue
+  fi
+
+  if [[ "$line" != FILE$'\t'* ]]; then
+    continue
+  fi
+
+  IFS=$'\t' read -r kind expected_hash relative_path <<< "$line"
+  if [[ "$kind" != "FILE" || -z "$relative_path" || -z "$expected_hash" ]]; then
+    echo "skip malformed manifest entry" >&2
+    continue
+  fi
+
+  if is_community_path "$relative_path" && [[ "$INCLUDE_COMMUNITY" -ne 1 ]]; then
+    echo "skip community path (opt-in required): ${relative_path}" >&2
+    continue
+  fi
+
+  if ! is_allowed_relative_path "$relative_path"; then
+    echo "skip disallowed manifest path: ${relative_path}" >&2
+    continue
+  fi
+
+  source_path="${TARGET_DIR}/${relative_path}"
+  destination_path="${ROOT_DIR}/${relative_path}"
+
+  if [[ ! -f "$source_path" ]]; then
+    echo "skip missing backup file: ${relative_path}" >&2
+    continue
+  fi
+
+  actual_hash="$(hash_file "$source_path")"
+  if [[ "$actual_hash" != "$expected_hash" ]]; then
+    echo "skip hash mismatch: ${relative_path}" >&2
+    continue
+  fi
+
+  restore_cmd "$source_path" "$destination_path"
+done < "$MANIFEST_PATH"
+
+echo "rollback applied from: ${TARGET_DIR}"

--- a/system-status-snapshot.md
+++ b/system-status-snapshot.md
@@ -734,3 +734,8 @@ _Auto update: $(date '+%Y-%m-%d %H:%M:%S')_
 - `scripts/impact-intl-runtime-backup.sh` es `scripts/impact-intl-runtime-rollback.sh`: duplikalt legacy blokk eltavolitva, egyetlen kanonikus implementacio maradt.
 - Community backup/rollback csak explicit `--include-community --ack-include-community` eseten engedelyezett.
 - CI kiegeszites: `.github/workflows/impact-community-source-guard.yml` ellenorzi a canonical guard jelenletet.
+
+## 2026-05-05 impact-community source guard hardening (review-fix)
+- `guarded-remote-write.sh`: anti-shrink override aktiv (`--allow-shrink`) es hash-elsodleges canonical check, worktree-kompatibilis elfogadassal.
+- `impact-intl-runtime-rollback.sh`: partial rollback mar nem jelent sikeres lefutast, hibara fail-closed kimenet van.
+- `impact-community-source-guard.yml`: marker-grep helyett futtathato parity check lepesei validaljak a guard viselkedest.

--- a/system-status-snapshot.md
+++ b/system-status-snapshot.md
@@ -728,3 +728,9 @@ _Auto update: $(date '+%Y-%m-%d %H:%M:%S')_
 - PHP: Vonage unicode type fix, version=0.3.8
 - Prod deploy: OK (wp-cli verified 0.3.8)
 ## JVK Dashboard Merge (2026-05-04)
+
+## 2026-05-05 impact-community source guard hardening
+- `scripts/guarded-remote-write.sh`: canonical path + sha256 ellenorzes kotelezo `impact-community.php` deploy elott.
+- `scripts/impact-intl-runtime-backup.sh` es `scripts/impact-intl-runtime-rollback.sh`: duplikalt legacy blokk eltavolitva, egyetlen kanonikus implementacio maradt.
+- Community backup/rollback csak explicit `--include-community --ack-include-community` eseten engedelyezett.
+- CI kiegeszites: `.github/workflows/impact-community-source-guard.yml` ellenorzi a canonical guard jelenletet.

--- a/system-status-snapshot.md
+++ b/system-status-snapshot.md
@@ -739,3 +739,7 @@ _Auto update: $(date '+%Y-%m-%d %H:%M:%S')_
 - `guarded-remote-write.sh`: anti-shrink override aktiv (`--allow-shrink`) es hash-elsodleges canonical check, worktree-kompatibilis elfogadassal.
 - `impact-intl-runtime-rollback.sh`: partial rollback mar nem jelent sikeres lefutast, hibara fail-closed kimenet van.
 - `impact-community-source-guard.yml`: marker-grep helyett futtathato parity check lepesei validaljak a guard viselkedest.
+
+## 2026-05-05 impact-community source guard hardening (workflow stabilizalas)
+- `impact-community-source-guard.yml` workflow job timeout 5 percre allitva.
+- A non-canonical rejection parity lepesben `REMOTE_LINES_OVERRIDE=1` hasznalat, hogy semmilyen halozati mellekhatas ne akassza meg a CI futast.

--- a/system-status-snapshot.md
+++ b/system-status-snapshot.md
@@ -743,3 +743,6 @@ _Auto update: $(date '+%Y-%m-%d %H:%M:%S')_
 ## 2026-05-05 impact-community source guard hardening (workflow stabilizalas)
 - `impact-community-source-guard.yml` workflow job timeout 5 percre allitva.
 - A non-canonical rejection parity lepesben `REMOTE_LINES_OVERRIDE=1` hasznalat, hogy semmilyen halozati mellekhatas ne akassza meg a CI futast.
+
+## 2026-05-05 impact-community source guard hardening (workflow parity path fix)
+- A non-canonical CI teszt mutalt fajlja most `impact-community.php` neven jon letre ideiglenes mappaban, hogy biztosan a guard relevans kodag fusson.


### PR DESCRIPTION
## Summary

- Scope:
  - `scripts/guarded-remote-write.sh`: canonical source path + sha256 guard added for `impact-community.php` deploy.
  - `scripts/impact-intl-runtime-backup.sh`: deduplicated to single canonical implementation; community files opt-in only.
  - `scripts/impact-intl-runtime-rollback.sh`: deduplicated to single canonical implementation; community restore opt-in only.
  - `.github/workflows/impact-community-source-guard.yml`: CI check that canonical source/hash guard markers stay present.
  - Continuity docs: `docs/protected-change-records/2026-05-05-impact-community-source-guard-hardening.md`, `system-status-snapshot.md`, `notes.md`.
- Why:
  - Prevent recurrence of wrong-source `impact-community.php` overwrite and accidental community restore through intl rollback lane.
- Risk:
  - Low/Medium (process hardening only, no runtime business logic change in community endpoints).
- Impact Challenge perimeter touched:
  - Yes (guard/deploy scripts and intl runtime lane scripts).
- Additive new-code solution used:
  - Yes.
- Legacy/protected-file touch approved by:
  - N/A (no protected MU runtime file content changed in this PR).
- Coherence analysis summary:
  - Backup/rollback scripts now have one canonical implementation each; removed duplicated legacy+new split to avoid ambiguous behavior.
- Risk analysis summary:
  - Primary risk is stricter guard potentially blocking manual emergency workflow; explicit documented bypass remains available.
- Affected functions to verify after merge/deploy:
  - `scripts/guarded-remote-write.sh` canonical source/hash check path.
  - `scripts/impact-intl-runtime-backup.sh` community opt-in gate.
  - `scripts/impact-intl-runtime-rollback.sh` manifest + community opt-in gate.
- Manual UI checklist for reviewer:
  - N/A (backend/script/CI only).

## Validation

- [x] Relevant build/test commands passed
- [x] `safe-repo-audit.sh --strict --mode push` passed
- [x] Deploy/smoke verification documented (if applicable)
- [x] Rollback path documented
- [x] Impact Challenge guard/write-protection rule checked (if applicable)
- [x] Protected-file coherence/risk review attached (if applicable)

## PR Exit Checklist (Required)

- [x] 1. Work was done on dedicated branch/worktree (not `main`)
- [x] 2. Relevant build/tests ran and are green
- [x] 3. `safe-repo-audit.sh --strict --mode push` is green
- [x] 4. `system-status-snapshot.md` updated for module change
- [x] 5. At least one `docs/*.md` updated for module change
- [x] 6. `notes.md` or `conversation-summaries/*` updated (notes-context repos)
- [ ] 7. `docs/bastion-guard-status.md` updated when new module file was added
- [x] 8. Deploy guard + smoke checks are logged (if deploy happened)
- [x] 9. Backup/rollback path is recorded
- [x] 10. PR description includes scope, risk, validation, deploy/rollback notes
- [x] 11. Impact Challenge changes are additive-first, or explicit legacy approval is documented
- [x] 12. Legacy protected-file touch includes approval + why additive approach was insufficient
- [x] 13. Deploy notes confirm protected files return to read-only after deploy
- [x] 14. Protected-file coherence analysis and risk analysis are documented
- [x] 15. Affected-function verification list is documented
- [x] 16. Manual UI checklist for reviewer/user is documented
