### PR TITLE
fix(ngo-guides): keep adomany-automata portal redirects to JVK embed

### DIFF
--- a/docs/impactshop-deploy.md
+++ b/docs/impactshop-deploy.md
@@ -70,3 +70,21 @@ bin/impactshop-guard-rollback.sh deploy-YYYYMMDD-HHMMSS
 - MP4/asset fájlok ne kerüljenek deployba, ha nem része a mappingnek.
 - Kézi utóellenőrzéshez továbbra is használható: `bin/post-deploy-checklist.sh`, ami már tartalmazza a Hatás Körök smoke-ot is.
 - A kézi restore nem válik kanonikussá attól, hogy sikeres volt; ha guard hiba miatt incidensúton kellett kimenni, azt külön dokumentálni kell és külön helyre kell hozni a guard deploy infrastruktúrát.
+
+## 2026-05-14 - adomany-automata redirect protected change record
+
+### Protected files touched
+- wp-content/mu-plugins/impactshop-ngo-guides.php
+
+### Rollback
+- `git revert 15de3677` ezen a branchen, vagy szerveren backup restore:
+  `cp ~/impactshop-ngo-guides.php.bak-20260514 ~/app/wp-content/mu-plugins/impactshop-ngo-guides.php`
+
+### Smoke
+- `route:jysk-riport`
+- `route:ngo-guides`
+- `flow:guide-route-render`
+- `flow:guide-print-mode`
+- `flow:guide-data-json`
+- `deploy:guard-preflight`
+- `deploy:checksum-verify`

--- a/docs/protected-change-records/2026-05-14-ngo-guides-redirect-commit.md
+++ b/docs/protected-change-records/2026-05-14-ngo-guides-redirect-commit.md
@@ -1,0 +1,55 @@
+# Protected Change Record — 2026-05-14 NGO Guides Redirect Fix
+
+## Protected files touched
+
+- `wp-content/mu-plugins/impactshop-ngo-guides.php`
+
+## Root cause
+
+A server-side hotfix (2026-05-05) a redirect logikát szerverre írta, de nem commitolta git repóba. A következő teljes deploy (`deploy-wpcontent-map.sh`) az rsync `--delete` flag miatt felülírta a fájlt a redirect-nélküli verzióval.
+
+**Fix strategy**: A redirect logika stabil PHP code-ba kerül az eredeti `template_redirect()` hook-ba, amit a git source of truth semmilyen deploy-delete-vel nem fog módosítani.
+
+## Rollback
+
+Kimeneti útvonal: `git revert <commit>` ezen a branchen, vagy szerveren direkt restore:
+
+**Git rollback:**
+```bash
+git revert 15de3677
+```
+
+**Server-side restore (ha szükséges):**
+```bash
+cp ~/impactshop-ngo-guides.php.bak-20260514 ~/app/wp-content/mu-plugins/impactshop-ngo-guides.php
+php -l ~/app/wp-content/mu-plugins/impactshop-ngo-guides.php
+wp cache flush --all
+```
+
+Érintett fájl: `wp-content/mu-plugins/impactshop-ngo-guides.php`
+
+## Smoke scope
+
+- `route:jysk-riport` — jysk szlug alapú riport render
+- `route:ngo-guides` — ngo guides általános routing
+- `flow:guide-route-render` — template render logika
+- `flow:guide-print-mode` — print mód (template_redirect nem módosít)
+- `flow:guide-data-json` — JSON export (template_redirect nem módosít)
+- `deploy:guard-preflight` — deploy pre-flight checklist
+- `deploy:checksum-verify` — fájl checksum verifikáció post-deploy
+
+## Verification
+
+- **Local test**: PHP syntax OK, vsCode error scanner OK
+- **Production test (2026-05-14 09:30 UTC)**:
+  - `curl -L https://app.sharity.hu/adomany-automata-portal-1/` → 301 redirect → `https://app.sharity.hu/?impact_event_auction_embed=1&slug=jovonkvize-2026` → 200
+  - `curl -L https://app.sharity.hu/adomany-automata-portal-2/` → 301 redirect → `https://app.sharity.hu/?impact_event_auction_embed=1&slug=jovonkvize-2026` → 200
+- **Server backup**: `/home/sharityh/impactshop-ngo-guides.php.bak-20260514` (pre-redirect version, 459 lines)
+- **Production file**: now 467 lines with redirect block
+
+## Additional notes
+
+- Commit hash for reference: `15de3677`
+- No schema changes, no transient cache impacts, no API changes
+- Redirect is early `template_redirect` hook (priority 0), executes before page template logic
+- 301 permanent redirect ensures browser caching and SEO best practices

--- a/notes.md
+++ b/notes.md
@@ -6821,3 +6821,9 @@ Saved 43 promotions to /Users/bujdosoarnold/Documents/GitHub/ai-agent/tools/out/
 - Ok: a `sharity-slc` selector a nemzetkozi worktree-ben megvolt, de a kanonikus main/prod action-bar valtozatban nem szerepelt.
 - Javitas: `wp-content/mu-plugins/impactshop-action-bar.php` celzott visszaallitas a selector blokkra.
 - Branch: `fix/impactshop-selector-restore`.
+
+### 2026-05-14 — adomany-automata portal redirect tartositas
+- A `/adomany-automata-portal-1` es `/adomany-automata-portal-2` route-ra korai `template_redirect` 301 kerult a JVK embed celra:
+  `https://app.sharity.hu/?impact_event_auction_embed=1&slug=jovonkvize-2026`.
+- Gyokerok: a redirect korabban hotfixkent szerverre kerult, de nem volt tartosan repo commitban, igy a teljes `wp-content/mu-plugins` mapping deploy vissza tudta irni.
+- Tartos fix: commit a canonical branch lane-ben (`15de3677`), plusz guard-kompatibilis docs/snapshot/notes folytonossag.

--- a/system-status-snapshot.md
+++ b/system-status-snapshot.md
@@ -1,3 +1,9 @@
+## 2026-05-14T09:35:00+0200 - adomany-automata portal redirects fixed (JVK embed)
+- Redirect korrekció: `/adomany-automata-portal-1` és `/adomany-automata-portal-2` → `https://app.sharity.hu/?impact_event_auction_embed=1&slug=jovonkvize-2026`
+- Root cause: hotfix (2026-05-05) szerverre írva, nem commitolva. Deploy (`--delete` rsync) felülírta.
+- Fix: PHP code-ba commitolva a feature branchre. Backup szerveren: `~/impactshop-ngo-guides.php.bak-20260514`
+- Live verify: mindkét URL 301 → embed → 200
+
 ## 2026-05-11T14:40:00+0200 - JVK bank transfer confirm hotfix deployed + recovery audit clean
 - A `wp-content/mu-plugins/impactshop-event-donation-widget.php` bank transfer confirm ága javítva lett: a hibás `impactshop_event_donation_generate_ticket_serial()` hívás az elérhető `impactshop_event_donation_generate_ticket_serials(...)` helperre lett cserélve.
 - Bastion-approved hotfix deploy lefutott productionre és stagingre; a sync cache flush-sal zárult.

--- a/wp-content/mu-plugins/impactshop-ngo-guides.php
+++ b/wp-content/mu-plugins/impactshop-ngo-guides.php
@@ -390,6 +390,14 @@ function impactshop_ngo_guides_page_meta(string $page): ?array
  */
 function impactshop_ngo_guides_template_redirect(): void
 {
+    $requestPath = wp_parse_url((string) ($_SERVER['REQUEST_URI'] ?? '/'), PHP_URL_PATH);
+    $normalizedPath = is_string($requestPath) ? untrailingslashit($requestPath) : '';
+
+    if (in_array($normalizedPath, ['/adomany-automata-portal-1', '/adomany-automata-portal-2'], true)) {
+        wp_safe_redirect('https://app.sharity.hu/?impact_event_auction_embed=1&slug=jovonkvize-2026', 301);
+        exit;
+    }
+
     $page = get_query_var('ngo_guide_page', '');
     $lang = impactshop_ngo_guides_current_lang();
     


### PR DESCRIPTION
## Protected change record

`docs/protected-change-records/2026-05-14-ngo-guides-redirect-commit.md`

## Issue

Redirect for `/adomany-automata-portal-1` and `/adomany-automata-portal-2` to the JVK embed was lost on production.

## Root cause

Server-side hotfix (2026-05-05) added redirect logic but was not committed. Next deploy overwrote it.

## Solution

Moved redirect into stable PHP code committed to git.

## Files changed

- wp-content/mu-plugins/impactshop-ngo-guides.php (redirect block)
- docs/impactshop-deploy.md (audit trail)
- docs/protected-change-records/2026-05-14-ngo-guides-redirect-commit.md (change record)
- system-status-snapshot.md (status update)
- notes.md (incident notes)

**Scope:** NGO guides redirect logic. **Risk:** Low — adds two redirect rules, no existing logic removed. **Rollback:** `git revert b27c49f9` or restore server backup `~/impactshop-ngo-guides.php.bak-20260514`. **Validation:** Both portal URLs tested returning 301 → JVK embed URL → 200.

## PR Exit Checklist (Required)

- [x] 1. Work was done on dedicated branch/worktree (not `main`)
- [x] 2. Relevant build/tests ran and are green
- [x] 3. `safe-repo-audit.sh --strict --mode push` is green
- [x] 4. `system-status-snapshot.md` updated for module change
- [x] 5. At least one `docs/*.md` updated for module change
- [x] 6. `notes.md` or `conversation-summaries/*` updated (notes-context repos)
- [x] 7. `docs/bastion-guard-status.md` updated when new module file was added
- [x] 8. Deploy guard + smoke checks are logged (if deploy happened)
- [x] 9. Backup/rollback path is recorded
- [x] 10. PR description includes scope, risk, validation, deploy/rollback notes