### PR TITLE
fix(auction): add JVK lot integrity guard

### DIFF
--- a/bin/jvk-auction-lot-guard.sh
+++ b/bin/jvk-auction-lot-guard.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TARGET_FILE="${1:-${ROOT_DIR}/wp-content/mu-plugins/impactshop-event-auction-widget.php}"
+
+if [[ ! -f "${TARGET_FILE}" ]]; then
+  echo "❌ JVK lot guard: missing target file: ${TARGET_FILE}" >&2
+  exit 1
+fi
+
+EXPECTED_COUNT=11
+EXPECTED_SPECS=(
+  "1:szentpeteri-toth-marta-forgiveness"
+  "2:simon-m-veronika-kek-sugarzas"
+  "3:tarcsi-daniel-part-iii"
+  "4:ghyczy-gyorgy-elindulok-a-csillagokhoz"
+  "5:szabo-anna-cseresznye"
+  "6:szabo-anna-a-no-turkizben"
+  "7:dimenzio-ingatlan-sirocco-elmenyvitorlazas"
+  "8:n28-wine-kitchen-uzleti-ebed"
+  "9:dedikalt-meccslabda-magyarorszag-argentina-2005"
+  "10:balla-gemma-ecoprint-selyemsal-nyaklac"
+  "11:kocsis-katica-weiler-peter-dedikalt-konyv"
+)
+
+php /dev/stdin "${TARGET_FILE}" "${EXPECTED_COUNT}" "${EXPECTED_SPECS[@]}" <<'PHP'
+<?php
+$targetFile = $argv[1];
+$expectedCount = (int) $argv[2];
+$expectedSpecs = array_slice($argv, 3);
+$contents = file_get_contents($targetFile);
+
+if ($contents === false) {
+    fwrite(STDERR, "❌ JVK lot guard: unable to read target file\n");
+    exit(1);
+}
+
+$actualCount = preg_match_all("/'lot_number'\\s*=>\\s*\\d+/", $contents, $matches);
+if ($actualCount < $expectedCount) {
+    fwrite(STDERR, "❌ JVK lot guard: only {$actualCount} lots found, expected at least {$expectedCount}\n");
+    exit(1);
+}
+
+$failed = false;
+foreach ($expectedSpecs as $spec) {
+    [$lotNumber, $lotSlug] = explode(':', $spec, 2);
+    $pattern = "/'item_slug'\\s*=>\\s*'" . preg_quote($lotSlug, "/") . "'(?:(?!\\[|\\],).)*'lot_number'\\s*=>\\s*" . preg_quote($lotNumber, "/") . "/s";
+    if (!preg_match($pattern, $contents)) {
+        fwrite(STDERR, "❌ JVK lot guard: missing or mismatched lot {$lotNumber} ({$lotSlug})\n");
+        $failed = true;
+    }
+}
+
+if ($failed) {
+    exit(1);
+}
+
+fwrite(STDOUT, "✅ JVK lot guard passed: {$actualCount} lots present, canonical 1-11 set intact\n");
+PHP

--- a/wp-content/mu-plugins/impactshop-event-auction-widget.php
+++ b/wp-content/mu-plugins/impactshop-event-auction-widget.php
@@ -17,9 +17,11 @@ define('IMPACTSHOP_EVENT_AUCTION_BIDDER_TTL', 4 * HOUR_IN_SECONDS);
 
 add_action('init', 'impactshop_event_auction_ensure_schema', 5);
 add_action('init', 'impactshop_event_auction_cron_schedule', 10);
+add_action('init', 'impactshop_event_auction_validate_runtime_integrity', 20);
 add_action('rest_api_init', 'impactshop_event_auction_register_routes');
 add_action('template_redirect', 'impactshop_event_auction_query_api_dispatch', 0);
 add_action('template_redirect', 'impactshop_event_auction_embed_page_dispatch', 1);
+add_action('admin_notices', 'impactshop_event_auction_admin_integrity_notice');
 add_filter('allowed_http_origins', 'impactshop_event_auction_allowed_http_origins');
 add_filter('allowed_redirect_hosts', 'impactshop_event_auction_allowed_redirect_hosts');
 add_shortcode('impact_event_auction_widget', 'impactshop_event_auction_shortcode');
@@ -341,6 +343,154 @@ function impactshop_event_auction_default_lots(): array
     }
 
     return $lots;
+}
+
+function impactshop_event_auction_required_lot_index(): array
+{
+    return [
+        1 => 'szentpeteri-toth-marta-forgiveness',
+        2 => 'simon-m-veronika-kek-sugarzas',
+        3 => 'tarcsi-daniel-part-iii',
+        4 => 'ghyczy-gyorgy-elindulok-a-csillagokhoz',
+        5 => 'szabo-anna-cseresznye',
+        6 => 'szabo-anna-a-no-turkizben',
+        7 => 'dimenzio-ingatlan-sirocco-elmenyvitorlazas',
+        8 => 'n28-wine-kitchen-uzleti-ebed',
+        9 => 'dedikalt-meccslabda-magyarorszag-argentina-2005',
+        10 => 'balla-gemma-ecoprint-selyemsal-nyaklac',
+        11 => 'kocsis-katica-weiler-peter-dedikalt-konyv',
+    ];
+}
+
+function impactshop_event_auction_lot_integrity_report(array $lots): array
+{
+    $expected = impactshop_event_auction_required_lot_index();
+    $seen = [];
+    $duplicateSlugs = [];
+    $duplicateNumbers = [];
+    $missing = [];
+    $mismatched = [];
+
+    foreach ($lots as $lot) {
+        $slug = sanitize_title((string) ($lot['item_slug'] ?? ''));
+        $number = (int) ($lot['lot_number'] ?? 0);
+
+        if ($slug !== '') {
+            if (isset($seen['slug'][$slug])) {
+                $duplicateSlugs[] = $slug;
+            }
+            $seen['slug'][$slug] = true;
+        }
+
+        if ($number > 0) {
+            if (isset($seen['number'][$number])) {
+                $duplicateNumbers[] = $number;
+            }
+            $seen['number'][$number] = $slug;
+        }
+    }
+
+    foreach ($expected as $number => $slug) {
+        if (!isset($seen['number'][$number])) {
+            $missing[] = sprintf('lot %d (%s)', $number, $slug);
+            continue;
+        }
+
+        if ($seen['number'][$number] !== $slug) {
+            $mismatched[] = sprintf(
+                'lot %d expected %s but found %s',
+                $number,
+                $slug,
+                $seen['number'][$number] !== '' ? $seen['number'][$number] : '(empty)'
+            );
+        }
+    }
+
+    return [
+        'ok' => count($lots) >= count($expected)
+            && $missing === []
+            && $mismatched === []
+            && $duplicateSlugs === []
+            && $duplicateNumbers === [],
+        'expected_count' => count($expected),
+        'actual_count' => count($lots),
+        'missing' => $missing,
+        'mismatched' => $mismatched,
+        'duplicate_slugs' => array_values(array_unique($duplicateSlugs)),
+        'duplicate_numbers' => array_values(array_unique($duplicateNumbers)),
+    ];
+}
+
+function impactshop_event_auction_runtime_lot_integrity_report(): array
+{
+    static $report = null;
+    if (is_array($report)) {
+        return $report;
+    }
+
+    $campaign = impactshop_event_auction_get_campaign('jovonkvize-2026');
+    $lots = is_array($campaign) ? (array) ($campaign['lots'] ?? []) : [];
+    $report = impactshop_event_auction_lot_integrity_report($lots);
+
+    return $report;
+}
+
+function impactshop_event_auction_validate_runtime_integrity(): void
+{
+    $report = impactshop_event_auction_runtime_lot_integrity_report();
+    if (!empty($report['ok'])) {
+        return;
+    }
+
+    $transientKey = 'impactshop_ea_jvk_lot_guard_alert';
+    if (get_transient($transientKey)) {
+        return;
+    }
+
+    set_transient($transientKey, '1', 10 * MINUTE_IN_SECONDS);
+
+    error_log('[impactshop-event-auction] JVK lot integrity guard failed: ' . wp_json_encode([
+        'actual_count' => (int) ($report['actual_count'] ?? 0),
+        'expected_count' => (int) ($report['expected_count'] ?? 0),
+        'missing' => array_values((array) ($report['missing'] ?? [])),
+        'mismatched' => array_values((array) ($report['mismatched'] ?? [])),
+        'duplicate_slugs' => array_values((array) ($report['duplicate_slugs'] ?? [])),
+        'duplicate_numbers' => array_values((array) ($report['duplicate_numbers'] ?? [])),
+    ]));
+}
+
+function impactshop_event_auction_admin_integrity_notice(): void
+{
+    if (!current_user_can('manage_options')) {
+        return;
+    }
+
+    $report = impactshop_event_auction_runtime_lot_integrity_report();
+    if (!empty($report['ok'])) {
+        return;
+    }
+
+    $issues = array_merge(
+        (array) ($report['missing'] ?? []),
+        (array) ($report['mismatched'] ?? []),
+        array_map(
+            static fn($slug) => 'duplicate slug: ' . $slug,
+            (array) ($report['duplicate_slugs'] ?? [])
+        ),
+        array_map(
+            static fn($number) => 'duplicate lot number: ' . (int) $number,
+            (array) ($report['duplicate_numbers'] ?? [])
+        )
+    );
+
+    echo '<div class="notice notice-error"><p><strong>JVK aukció lot guard hiba:</strong> ';
+    echo esc_html(sprintf(
+        'A widget %d helyett %d kötelező tételt lát. %s',
+        (int) ($report['expected_count'] ?? 0),
+        (int) ($report['actual_count'] ?? 0),
+        implode(' | ', $issues)
+    ));
+    echo '</p></div>';
 }
 
 function impactshop_event_auction_get_campaign(string $slug): ?array


### PR DESCRIPTION
## Summary
- add a runtime integrity guard for the canonical 11 JVK auction lots
- add an admin notice and error-log signal when any required lot disappears or shifts
- add a deploy-time ✅ JVK lot guard passed: 11 lots present, canonical 1-11 set intact script that fails fast on stale 7/9-lot source files

## Verification
- No syntax errors detected in wp-content/mu-plugins/impactshop-event-auction-widget.php
- ✅ JVK lot guard passed: 11 lots present, canonical 1-11 set intact

## Scope
- JVK auction widget only
- no changes to donation widget or other worktrees