### PR TITLE
fix(vb2026): canonize source profile-return lane

### DIFF
--- a/docs/bastion-guard-status.md
+++ b/docs/bastion-guard-status.md
@@ -1,6 +1,6 @@
 # Bastion Guard Status
 
-Last updated: 2026-04-29 09:50 CEST
+Last updated: 2026-06-14 08:20 UTC
 
 ## 2026-03-26 19:45 — impact-community.php URL fix
 - `ngo_admin_url` és `reset_url` dedikált `/ngo-admin/` route-ra állítva; a legacy `/impact-shop_ngo/` oldal többé nem kanonikus NGO admin belépési pont.
@@ -16,6 +16,7 @@ Ez a fájl a kötelező evidencianapló minden új modulhoz tartozó bástya/gua
 ## Kiterjesztési napló
 | Dátum | Modul | Guard kiterjesztés | Evidencia |
 | --- | --- | --- | --- |
+| 2026-06-14 | `impactshop-identity-panel.php`, `impactshop-identity-panel.js`, `docs/impactshop-guard-config.json`, `docs/impactshop-protected-files.json` | VB2026 profile-return source canonicalization: a protected identity runtime most mar kulon account-top es restore-fragment deeplinkkel dolgozik, es save/restore utan a FactLens `profile-return/complete` session-helyreallito hopjara ad vissza. A bridge source plugin a guard inventoryben explicit protected lane lett, az identity-panel runtime pedig ezzel egyutt kezelendo bastion-coupled felulet. | `docs/protected-change-records/2026-06-14-vb2026-profile-return-session-carry.md`, `notes.md`, `system-status-snapshot.md` |
 | 2026-05-12 | `impactshop-action-bar.php` | Celozott hotfix: visszaallitva a nyelv/orszag selector (`sharity-slc`) a kanonikus main/prod lane-ben. Protected touch override alatt ment, dedikalt change record + rollback + smoke scope mellett. | `docs/protected-change-records/2026-05-12-impactshop-selector-restore-hotfix.md`, `notes.md`, `system-status-snapshot.md` |
 | 2026-05-07 | `impactshop-ads-watch-intl-overlay.js`, `impactshop-identity-panel-intl-overlay.js`, `impactshop-ads-watch.php`, `impactshop-ads-watch.js`, `impactshop-identity-panel.php` | Tiszta release-worktree-ben kanonizalt intl runtime csomag a mar live-on validalt EN shop es EN challenge allapothoz. Az uj overlay assetek additiv `app-content` lane-ben kerultek be, a protected runtime touch kulon commitban ment at explicit change record + rollback + smoke scope mellett. | `docs/protected-change-records/2026-05-07-impactshop-intl-runtime-canonicalize.md`, `notes.md`, `system-status-snapshot.md` |
 | 2026-04-29 | `impactshop-event-auction-widget.php`, `impactshop-event-auction-widget-jovonkvize-1.0.0.js` | Additiv uj modul a Jovonk Vize aukcios lane-hez. Protected legacy donation widget fajlokhoz ez a change set nem nyult. A ket runtime fajl celzott staging sync-kel kiment az `app-staging` peldanyra, a read-only vedelem visszazarva; public read lane, session-tokenes bidder regisztracio, tranzakcios bid lane, direkt backend admin close es Stripe winner-payment backend staging smoke-kal igazolt. A route-szintu admin REST smoke-ot jelenleg a staging capability-drift blokkolja (`manage_options` nem latszik egy usernel sem), a payment completion pedig elo Stripe kulcs miatt nem futott tovabb. | `wp-content/mu-plugins/impactshop-event-auction-widget.php`, `wp-content/mu-plugins/impactshop-event-auction-widget-jovonkvize-1.0.0.js`, `docs/jovonkvize-auction-widget-scaffold-2026-04-29.md`, `notes.md` |

--- a/docs/impactshop-guard-config.json
+++ b/docs/impactshop-guard-config.json
@@ -170,6 +170,12 @@
       "owner_branch": "main"
     },
     {
+      "path": "wp-content/mu-plugins/impactshop-factlens-identity-bridge.php",
+      "owner_repo": "https://github.com/office-hue/impactshop-notes.git",
+      "owner_root": "/Users/bujdosoarnold/Developer/GitHub/impactshop-notes",
+      "owner_branch": "main"
+    },
+    {
       "path": "wp-content/mu-plugins/impactshop-vote-jysk.php",
       "owner_repo": "https://github.com/office-hue/impactshop-notes.git",
       "owner_root": "/Users/bujdosoarnold/Developer/GitHub/impactshop-notes",

--- a/docs/impactshop-protected-files.json
+++ b/docs/impactshop-protected-files.json
@@ -33,6 +33,7 @@
     "wp-content/mu-plugins/impactshop-ayet-offerwall.php",
     "wp-content/mu-plugins/impactshop-full-leaderboard.php",
     "wp-content/mu-plugins/impactshop-rest-totals.php",
+    "wp-content/mu-plugins/impactshop-factlens-identity-bridge.php",
     "wp-content/mu-plugins/impactshop-identity-panel.php",
     "wp-content/mu-plugins/impactshop-identity-panel.js",
     "wp-content/mu-plugins/impactshop-ngo-selector.php",
@@ -106,11 +107,14 @@
       "browser:mobile"
     ],
     "identity_and_points": [
+      "route:factlens-vb-prod",
       "route:impact-challenge",
       "route:profil",
       "flow:message-popup",
       "flow:points-jump",
-      "flow:legacy-pool-visibility"
+      "flow:legacy-pool-visibility",
+      "flow:profile-return-account",
+      "flow:profile-return-restore"
     ],
     "mobile_shell_runtime": [
       "route:impact-challenge",
@@ -175,6 +179,7 @@
       "sw.js"
     ],
     "identity_and_points": [
+      "wp-content/mu-plugins/impactshop-factlens-identity-bridge.php",
       "wp-content/mu-plugins/impactshop-identity-panel.php",
       "wp-content/mu-plugins/impactshop-identity-panel.js",
       "wp-content/mu-plugins/impactshop-rest-totals.php",

--- a/docs/protected-change-records/2026-06-14-vb2026-profile-return-session-carry.md
+++ b/docs/protected-change-records/2026-06-14-vb2026-profile-return-session-carry.md
@@ -1,0 +1,22 @@
+# Protected Change Record
+
+- Date: 2026-06-14
+- Scope: VB2026 profile-return source lane canonicalization
+- Reason: A FactLens `vb-prod` profile-return flow-nak a Sharity source oldalon kulon account-top es restore-fragment deeplinket, valamint save/restore utani target-session-helyreallito visszaterest kell adnia.
+- Risk: Medium (protected identity runtime + cross-domain return lane)
+- Rollback: A commit teljes visszavonasa (`git revert <commit>`), vagy a megelőző repo-tracked `impactshop-identity-panel.php` / `impactshop-identity-panel.js` allapot visszaallitasa, szukseg eseten a FactLens host oldali rollbackkel egyutt.
+
+## Protected Files Touched
+
+- `wp-content/mu-plugins/impactshop-identity-panel.php`
+- `wp-content/mu-plugins/impactshop-identity-panel.js`
+- `docs/impactshop-guard-config.json`
+- `docs/impactshop-protected-files.json`
+
+## Validation Plan
+
+- `php -l wp-content/mu-plugins/impactshop-identity-panel.php`
+- `node --check wp-content/mu-plugins/impactshop-identity-panel.js`
+- `node -e "JSON.parse(fs.readFileSync('docs/impactshop-guard-config.json','utf8')); JSON.parse(fs.readFileSync('docs/impactshop-protected-files.json','utf8'));"`
+- Smoke scope: `route:profil`, `route:factlens-vb-prod`, `flow:profile-return-account`, `flow:profile-return-restore`
+- E2E expectation: account flow a profil tetejere menjen, restore flow a helyreallitas blokkra menjen, es sikeres save/restore utan a FactLens `auth/session` `connected_session` allapotot adjon.

--- a/notes.md
+++ b/notes.md
@@ -2,6 +2,12 @@
 - `impactshop-vote-purchase.js`: `getEffectiveCurrency()` fallback, `preferredCurrency` pre-select, `submitBtn`/`companyToggle` null guard
 - Root cause: `currencySelect` null → TypeError → Adományozom gomb néma. 3 commit: `c073391f`, `abcee270`, `649732f0`
 
+## 2026-06-14 08:20 UTC - VB2026 profile-return session carry kanonizalva
+- A Sharity source-side `impactshop-factlens-identity-bridge.php` vegleges shipping mintaja mar nem csak lane-map redirectet ad, hanem a sikeres profile save/restore utan a FactLens `GET /api/vb2026/profile-return/complete` route-jara kuld vissza alairt `pseudo_id + return_to + ui_target + ts + sig` payloadot.
+- A ket CTA kulon deep-link szerzodese rogzitve: `Sharity profil megnyitasa` -> `/profil/?bridge_target=account#impactshop-account-top`, `Ez nem az en fiokom` -> `/profil/?bridge_target=restore#impactshop-restore-title`.
+- A source-side protected runtime coupling most mar kifejezetten egy lane-kent kezelendo: `impactshop-factlens-identity-bridge.php` + `impactshop-identity-panel.php` + `impactshop-identity-panel.js`.
+- Live evidence: a completion route a FactLens hoston `303` + `__Host-factlens_vb_session` cookie-t ad, es a visszaerkezes utani `auth/session` probe `connected_session` + maszkolt pseudo allapotot mutat.
+
 ## 2026-05-11 14:40 CEST - JVK bank transfer confirm hotfix + historical recovery lezárva
 - `impactshop-event-donation-widget.php`: a bank transfer admin confirm flow gyökérok javítva. A hibás, nem létező `impactshop_event_donation_generate_ticket_serial()` hívás az elérhető batch helperre lett cserélve: `impactshop_event_donation_generate_ticket_serials(...)`.
 - Deploy: a fix bastion-approved hotfix sync-kel ment ki productionre és stagingre. A deploy cache flush-sal zárult.

--- a/system-status-snapshot.md
+++ b/system-status-snapshot.md
@@ -1,3 +1,8 @@
+## 2026-06-14T08:20:00+0000 - VB2026 profile-return session carry canonicalized
+- A Sharity source-side profile-return lane kulon account-top es restore-fragment deeplink contractot kapott: `Sharity profil megnyitasa` -> `/profil/?bridge_target=account#impactshop-account-top`, `Ez nem az en fiokom` -> `/profil/?bridge_target=restore#impactshop-restore-title`.
+- A sikeres save/restore mar nem kozvetlen `vb-prod` redirecttel zar, hanem a FactLens `GET /api/vb2026/profile-return/complete` route-jara kuld vissza alairt payloadot, hogy a target host `__Host-factlens_vb_session` cookie-t issue-zon a vegso visszateres elott.
+- A source-side protected runtime coupling explicit lett: `impactshop-identity-panel.php`, `impactshop-identity-panel.js` es a guard inventoryben nyilvantartott `impactshop-factlens-identity-bridge.php` egy kozos VB2026 profile-return lane-kent kezelendo.
+
 ## 2026-06-03T08:00:00+0200 - vote-purchase JS null-safe currency fallback fix
 - `impactshop-vote-purchase.js`: `getEffectiveCurrency()` fallback hozzáadva — `currencySelect` null esetén `preferredCurrency`/`defaultCurrency` sorrendben esik vissza
 - Root cause: `currencySelect.value` TypeError → Adományozom gomb néma

--- a/wp-content/mu-plugins/impactshop-identity-panel.js
+++ b/wp-content/mu-plugins/impactshop-identity-panel.js
@@ -102,6 +102,33 @@
       }
     }
 
+    function getBridgeTarget() {
+      try {
+        const current = new URL(window.location.href);
+        const raw = String(current.searchParams.get("bridge_target") || "").toLowerCase();
+        if (raw === "restore") return "restore";
+        if (raw === "account") return "account";
+        return "";
+      } catch (e) {
+        return "";
+      }
+    }
+
+    function buildBridgeCompletionUrl(targetName) {
+      const target = targetName === "restore" ? "restore" : (targetName === "account" ? "account" : "");
+      if (!target) return "";
+      try {
+        const current = new URL(window.location.href);
+        current.hash = "";
+        current.searchParams.delete("return");
+        current.searchParams.set("bridge_target", target);
+        current.searchParams.set("impactshop_profile_return_complete", "1");
+        return current.toString();
+      } catch (e) {
+        return "";
+      }
+    }
+
     function attachReturnParamToRestoreLinks() {
       const links = root.querySelectorAll("[data-role=identity-restore-link]");
       if (!links.length) return;
@@ -125,6 +152,27 @@
           // ignore
         }
       });
+    }
+
+    function getBridgeCompletionUrl(preferredTarget) {
+      const activeTarget = preferredTarget || getBridgeTarget();
+      if (!activeTarget) return "";
+      return buildBridgeCompletionUrl(activeTarget);
+    }
+
+    function navigateAfterIdentityAction(targetUrl, fallbackUrl) {
+      const destination = targetUrl || fallbackUrl || "";
+      if (!destination) {
+        window.location.reload();
+        return;
+      }
+
+      if (typeof window.location.replace === "function") {
+        window.location.replace(destination);
+        return;
+      }
+
+      window.location.href = destination;
     }
 
     function refreshPseudo() {
@@ -1222,7 +1270,7 @@
       }
       syncSaveFields(pseudo, recovery);
       if (saveReturn) {
-        saveReturn.value = window.location.href;
+        saveReturn.value = getBridgeCompletionUrl("account") || window.location.href;
       }
       if (!saveForm) {
         setStatus("A mentés ezen a nézeten nem érhető el.", true);
@@ -1230,8 +1278,18 @@
       }
       tryCredentialStore(pseudo, recovery);
       triggerPasswordManagerSave(pseudo, recovery);
-      setStatus("Jelszókezelő mentés indítva.");
+      const bridgeCompletionUrl = getBridgeCompletionUrl("account");
+      if (bridgeCompletionUrl) {
+        setStatus("Jelszókezelő mentés indítva. Visszaléptetünk…");
+      } else {
+        setStatus("Jelszókezelő mentés indítva.");
+      }
       awardCredentialsSave(pseudo);
+      if (bridgeCompletionUrl) {
+        setTimeout(function(){
+          navigateAfterIdentityAction(bridgeCompletionUrl, "");
+        }, 900);
+      }
     }
     if (saveForm) {
       saveForm.addEventListener("submit", handleSavePassword);
@@ -1286,12 +1344,19 @@
           if (restoreStatus) restoreStatus.textContent = "Azonosító helyreállítva.";
           emitIdentityReady(pseudo);
           fetchProfile().then(refreshPointsSection);
+          const bridgeCompletionUrl = getBridgeCompletionUrl("restore");
           const returnUrl = getSafeReturnUrl();
-          if (returnUrl) {
+          if (bridgeCompletionUrl) {
             setStatus("Azonosító helyreállítva. Visszaléptetünk…");
             if (restoreStatus) restoreStatus.textContent = "Azonosító helyreállítva. Visszaléptetünk…";
             setTimeout(function(){
-              window.location.href = returnUrl;
+              navigateAfterIdentityAction(bridgeCompletionUrl, returnUrl);
+            }, 900);
+          } else if (returnUrl) {
+            setStatus("Azonosító helyreállítva. Visszaléptetünk…");
+            if (restoreStatus) restoreStatus.textContent = "Azonosító helyreállítva. Visszaléptetünk…";
+            setTimeout(function(){
+              navigateAfterIdentityAction("", returnUrl);
             }, 900);
           } else {
             setTimeout(function(){

--- a/wp-content/mu-plugins/impactshop-identity-panel.php
+++ b/wp-content/mu-plugins/impactshop-identity-panel.php
@@ -97,6 +97,7 @@ add_shortcode('impactshop_identity_id', 'impactshop_identity_id_shortcode');
 add_action('wp_enqueue_scripts', 'impactshop_identity_panel_register_assets');
 add_action('admin_init', 'impactshop_identity_register_broadcast_setting');
 add_action('init', 'impactshop_identity_handle_password_manager_save');
+add_action('template_redirect', 'impactshop_identity_maybe_complete_profile_return', 1);
 
 function impactshop_identity_register_broadcast_setting(): void
 {
@@ -696,9 +697,92 @@ function impactshop_identity_profile_valid_pseudo(string $pseudo_id): bool
 }
 
 /**
+ * Resolve requested bridge target from current request.
+ *
+ * @return string
+ */
+function impactshop_identity_requested_bridge_target(): string
+{
+    $value = isset($_REQUEST['bridge_target']) ? sanitize_text_field((string) wp_unslash($_REQUEST['bridge_target'])) : '';
+    if ($value === 'restore') {
+        return 'impactshop_restore';
+    }
+    if ($value === 'account') {
+        return 'impactshop_account';
+    }
+    return '';
+}
+
+/**
+ * Build native fallback profile URL for the given UI target.
+ *
+ * @param string $ui_target Bridge UI target.
+ * @return string
+ */
+function impactshop_identity_profile_native_fallback(string $ui_target): string
+{
+    $base = home_url('/profil/');
+    if ($ui_target === 'impactshop_restore') {
+        return $base . '#impactshop-restore-title';
+    }
+    return $base;
+}
+
+/**
+ * Complete profile-return redirect after a successful client-side action.
+ *
+ * @return void
+ */
+function impactshop_identity_maybe_complete_profile_return(): void
+{
+    if (is_admin()) {
+        return;
+    }
+
+    if (empty($_GET['impactshop_profile_return_complete'])) {
+        return;
+    }
+
+    $ui_target = impactshop_identity_requested_bridge_target();
+    if ($ui_target === '' || !function_exists('impactshop_factlens_profile_return_target')) {
+        return;
+    }
+
+    $target = impactshop_factlens_profile_return_target($ui_target, impactshop_identity_profile_native_fallback($ui_target));
+    if (!is_string($target) || $target === '') {
+        return;
+    }
+
+    $home_host = (string) wp_parse_url(home_url('/'), PHP_URL_HOST);
+    $target_host = (string) wp_parse_url($target, PHP_URL_HOST);
+    if ($target_host !== '' && $home_host !== '' && !hash_equals($home_host, $target_host)) {
+        wp_redirect($target, 303);
+        exit;
+    }
+
+    wp_safe_redirect($target, 303);
+    exit;
+}
+
+/**
  * Validate nickname format.
  *
  * @param string $nickname Nickname to validate.
+
+    $ui_target = impactshop_identity_requested_bridge_target();
+    if ($ui_target !== '' && function_exists('impactshop_factlens_profile_return_target')) {
+        $resolved = impactshop_factlens_profile_return_target($ui_target, impactshop_identity_profile_native_fallback($ui_target));
+        if (is_string($resolved) && $resolved !== '') {
+            $target_host = (string) wp_parse_url($resolved, PHP_URL_HOST);
+            $home_host = (string) wp_parse_url(home_url('/'), PHP_URL_HOST);
+            if ($target_host !== '' && $home_host !== '' && !hash_equals($home_host, $target_host)) {
+                wp_redirect($resolved, 303);
+                exit;
+            }
+            wp_safe_redirect($resolved, 303);
+            exit;
+        }
+    }
  * @return bool
  */
 function impactshop_identity_profile_valid_nickname(string $nickname): bool


### PR DESCRIPTION
## Scope
- canonize the Sharity-side profile-return lane for VB2026
- keep the account flow on the profile-top deeplink and the restore flow on the restore deeplink
- preserve FactLens session carry by routing successful save/restore through the signed completion hop
- extend protected inventory / bastion evidence to the coupled source bridge lane

## Risk
- medium: protected identity runtime (`impactshop-identity-panel.php/js`)
- no new ports, no committed live secrets

## Validation
- `php -l wp-content/mu-plugins/impactshop-identity-panel.php`
- `node --check wp-content/mu-plugins/impactshop-identity-panel.js`
- guard JSON parse ok
- live HTTP/browser evidence recorded in notes and system-status-snapshot

## Rollback
- `git revert` the protected commit, or restore the prior identity-panel php/js state and coordinate with the FactLens host rollback if a cross-domain mismatch appears
- protected change record: `docs/protected-change-records/2026-06-14-vb2026-profile-return-session-carry.md`