### PR TITLE
docs(governance): add impactshop-notes local governance hub

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@
 - Workspace global policy: `/Users/bujdosoarnold/AGENTS.md`
 - Shared assistant policy: `/Users/bujdosoarnold/Developer/GitHub/ai-agent/docs/ai-assistant-canonical-policy.md`
 - Local assistant policy: `docs/ai-assistant-canonical-policy.md`
+- Local governance hub / system plan: `docs/impactshop-governance-system-plan-2026-06-16.md`
 - Impact Challenge canonical baseline: `docs/impact-challenge-canonical-baseline.md`
 - PR / merge / deploy policy: `docs/pr-policy.md`
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 Cél: ImpactShop/WordPress integráció, akciós termékek linkjeinek javítása, karbantartása, affiliate hijacking védelem.
 
+## Governance Start Here
+
+- Helyi kanonikus governance-hub: `docs/impactshop-governance-system-plan-2026-06-16.md`
+- Repo munkaszabályok: `AGENTS.md`
+- PR / merge / deploy policy: `docs/pr-policy.md`
+- Exit checklist: `PR-EXIT-CHECKLIST.md`
+
 ## Legújabb fejlesztések
 - **13. beszélgetés (2025-09-21)**: Affiliate hijacking detektálás és védelem Dognet Publisher API integrációval
 - **Anti-hijack védelem**: JavaScript alapú real-time link monitoring és CHID paraméter ellenőrzés

--- a/docs/ai-fejlesztes-veglegesitett-masterterv-2026-03-04.md
+++ b/docs/ai-fejlesztes-veglegesitett-masterterv-2026-03-04.md
@@ -11,6 +11,16 @@
 3. Kanonikus issue script: `impactshop-notes/scripts/create-ai-issues.sh`.
 4. CI/workflow csak repókon belül számít kanonikusnak.
 5. Top-level duplikátumok read-only referenciának tekintendők.
+6. A repo-helyi governance entrypoint: `docs/impactshop-governance-system-plan-2026-06-16.md`.
+
+## 1.1) Helyi governance hub
+
+Az `impactshop-notes` repo helyi governance, review es continuity belepesi pontja:
+
+- `docs/impactshop-governance-system-plan-2026-06-16.md`
+- `docs/impactshop-governance-hub-coherence-audit-2026-06-16.md`
+
+Ez a hub nem valtja ki a kanonikus policy-dokumentumokat, hanem rovid belso rendszerterv/reference pontkent osszefogja a repo sajat anchorjait.
 
 ## 2) Válasz a kiemelt kérdésre (Phase 1–28 legal)
 
@@ -66,4 +76,3 @@ Indok:
 1. Implementáció előtt mindig a kanonikus forrás számít.
 2. Top-level nem használható „kész” állítás igazolására.
 3. A script csak jóváhagyott scope-pal futhat issue-nyitásra.
-

--- a/docs/impactshop-governance-hub-coherence-audit-2026-06-16.md
+++ b/docs/impactshop-governance-hub-coherence-audit-2026-06-16.md
@@ -1,0 +1,81 @@
+# ImpactShop Governance Hub Coherence Audit
+
+Datum: 2026-06-16
+Statusz: docs-only coherence audit
+Primary surface: `impactshop-notes` local governance / continuity
+Secondary affected surfaces: local PR/review entrypoint, masterplan reference layer
+
+## Why This Slice
+
+Az elozo helyi szelet letrehozta a rovid governance-hubot:
+
+- `docs/impactshop-governance-system-plan-2026-06-16.md`
+
+Ennek a kovetkezo legkisebb hasznos folytatasa egy szuk koherencia-audit, amely explicit modon ellenorzi, hogy a hub:
+
+1. valos helyi anchorokra mutat-e,
+2. nem nyit-e uj policy-lane-t,
+3. tenylegesen megkonnyiti-e a kovetkezo rollout szeleteket.
+
+## Scope
+
+Az audit csak a helyi governance es continuity reteget nezi:
+
+- `AGENTS.md`
+- `README.md`
+- `docs/pr-policy.md`
+- `PR-EXIT-CHECKLIST.md`
+- `docs/ai-fejlesztes-veglegesitett-masterterv-2026-03-04.md`
+- `docs/impactshop-governance-system-plan-2026-06-16.md`
+- `system-status-snapshot.md`
+- `notes.md`
+- `docs/bastion-guard-status.md`
+
+Nem erinti:
+
+- protected runtime kod
+- deploy lane
+- bastion konfiguracio
+- product/spec dokumentumok tartalmi ujranyitasat
+
+## Findings
+
+### Pass
+
+1. A governance-hub valos, letezo helyi anchorokat foglal ossze.
+2. A hub be van kotve a gyors belepesi pontokra:
+   - `AGENTS.md`
+   - `README.md`
+   - `docs/ai-fejlesztes-veglegesitett-masterterv-2026-03-04.md`
+3. A continuity minimum osszhangban maradt a repo sajat gyakorlataval:
+   - `docs/*.md`
+   - `system-status-snapshot.md`
+   - `notes.md`
+4. A szelet docs-only es additiv maradt; nem gyengitette a protected/perimeter szabalyokat.
+
+### Open but non-blocking
+
+1. A hub nem helyettesiti a reszletes protected-file change checklistet vagy a baseline dokumentumokat.
+2. A kovetkezo nem-docs szeletnel tovabbra is kulon koherencia- es kockazatvizsgalat kell, ha protected lane erintett.
+
+## Risk / Coherence / Security Note
+
+- Kockazat: alacsony
+- Koherencia: javult, mert a helyi governance-lanc immar egyetlen repo-beli entrypointrol is feloldhato
+- Biztonsag: valtozatlan vagy jobb, mert a dokumentum explicit modon megorzi a fail-closed protected-lane szemleletet
+
+## Validation
+
+1. Celozott anchor-ellenorzes futott a helyi governance fajlokra.
+2. A hub hivatkozasai letezo helyi fajlokra mutatnak.
+3. A bekotesek a `README.md`, `AGENTS.md` es a masterplan referenciartegben is ellenorizve lettek.
+4. `git diff --check` zold a docs-szeleten.
+
+## Next Smallest Safe Slice
+
+Innen a kovetkezo biztonsagos szelet mar lehet:
+
+1. egy konkret helyi rollout-/review-sablon finomitasa a hubra tamaszkodva, vagy
+2. egy kulon protected-lane elokeszito audit, ha valos runtime/deploy munka kovetkezik
+
+De a governance-hub szintjen kulon ujratervezes mar nem szukseges.

--- a/docs/impactshop-governance-system-plan-2026-06-16.md
+++ b/docs/impactshop-governance-system-plan-2026-06-16.md
@@ -1,0 +1,96 @@
+# ImpactShop Governance System Plan
+
+Datum: 2026-06-16
+Statusz: canonical local governance hub
+Scope: rovid, repo-helyi belepesi pont az `impactshop-notes` governance, review, continuity es protected-lane szabalyaihoz.
+
+## Cel
+
+Ez a dokumentum nem uj policy-t vezet be, hanem egyetlen helyi governance-hubkent osszefogja azokat a mar ervenyes kanonikus anchorokat, amelyek menten az `impactshop-notes` repo-ban a munka, review, continuity es protected-lane valtozas tortenik.
+
+## Canonical Anchors
+
+1. `AGENTS.md`
+   - a repo-szintu munkaszabalyok, canonical policy-sorrend, continuity es protected-file minimumok
+2. `docs/pr-policy.md`
+   - branch/worktree fegyelem, PR/merge/deploy kapuk, protected-file es review szabalyok
+3. `PR-EXIT-CHECKLIST.md`
+   - merge elotti kotelezo exit-feltetelek rovid ellenorzolistaja
+4. `docs/ai-assistant-canonical-policy.md`
+   - a helyi AI-asszisztens es protected/perimeter policy reszletesebb referenciapontja
+5. `docs/impact-challenge-canonical-baseline.md`
+   - az Impact Challenge protected es regresszio-ervenyes referenciaallapota
+6. `system-status-snapshot.md`
+   - a repo aktualis mukodesi/allapotvaltozasi naploja
+7. `notes.md`
+   - session-szintu folyamatos dontes-, kockazat- es teendolog
+8. `docs/bastion-guard-status.md`
+   - protected/perimeter es guard-bovitesek idobelyeges evidencianaploja
+
+## Recommended Reading Order
+
+1. `AGENTS.md`
+2. `docs/pr-policy.md`
+3. `PR-EXIT-CHECKLIST.md`
+4. az aktualis feladathoz kapcsolodo protected vagy baseline dokumentum
+5. `system-status-snapshot.md`
+6. `notes.md`
+
+## Operating Model
+
+1. Plan-first, szuk szelet
+   - a legkisebb reviewzhato szeletet valaszd
+   - a runtime, docs es deploy lane-eket ne keverd feleslegesen
+2. Worktree/branch discipline
+   - nem trivialis munka dedikalt worktree-ben menjen
+   - a lokalis truth nem keverheto mas repo vagy mas worktree irasaival
+3. Fail-closed protected lanes
+   - protected vagy bastion-csatolt feluletnel a default nem a gyors modositas, hanem az explicit koherencia, kockazat es rollback
+4. Continuity by default
+   - valos allapotvaltozas eseten a docs + `system-status-snapshot.md` + `notes.md` folyamatosan egyutt frissuljon
+
+## Decision Rules
+
+### Docs-only slice
+
+Docs-only szelet akkor a helyes valasztas, ha:
+
+- a kovetkezo lepes governance, review vagy continuity hianyossagot zar
+- runtime vagy protected kodhoz nem kell hozzanyulni
+- a kovetkezo implementacios szeletet ezzel egyszerubb es koherensebb lesz vegrehajtani
+
+### Protected/runtime slice
+
+Protected vagy runtime szeletnel kotelezo:
+
+- elozetes koherencia- es kockazatvizsgalat
+- rollback vagy restore ut tiszta rogzitese
+- a relevans smoke, QA vagy guard evidence rogzites
+- manualis reviewer/user checklist, ha UI vagy route viselkedes erintett
+
+## Continuity Minimum
+
+Valos repo-allapot valtozasnal legalabb ezeket kell egyben nezni:
+
+1. `docs/*.md`
+2. `system-status-snapshot.md`
+3. `notes.md` vagy `conversation-summaries/*`
+4. `docs/bastion-guard-status.md`, ha uj vedett/perimeter-modul vagy uj guard-szabaly jelenik meg
+
+## Scope Boundary
+
+Ez a hub az `impactshop-notes` sajat helyi governance-rendjet fogja ossze. Nem valtja ki:
+
+- a workspace-global policy-t
+- a shared `ai-agent` assistant policy-t
+- a protected baseline dokumentumokat
+- a konkret feature-, deploy- vagy incident-runbookokat
+
+## Natural Next Use
+
+A dokumentum celja, hogy barmely kovetkezo helyi szeletnel legyen egy rovid, repo-beli entrypoint:
+
+- uj munka inditasakor
+- PR/review elott
+- protected lane erintese elott
+- continuity ellenorzeshez

--- a/notes.md
+++ b/notes.md
@@ -1,3 +1,13 @@
+## 2026-06-16 10:20 CEST - local governance hub/system-plan
+- Docs-only governance szeletkent letrejott a rovid helyi belepesi pont: `docs/impactshop-governance-system-plan-2026-06-16.md`.
+- A cel nem uj policy bevezetese volt, hanem a mar elo helyi anchorok egyberendezese: `AGENTS.md`, `docs/pr-policy.md`, `PR-EXIT-CHECKLIST.md`, `system-status-snapshot.md`, `notes.md`, `docs/bastion-guard-status.md`.
+- Bekotes megtortent azonnali helyi megtalalhatosaghoz a `README.md`, az `AGENTS.md` canonical source listaja es a `docs/ai-fejlesztes-veglegesitett-masterterv-2026-03-04.md` felol.
+
+## 2026-06-16 10:55 CEST - governance hub coherence audit
+- A hub kovetkezo legkisebb folytatasakent rovid helyi audit keszult: `docs/impactshop-governance-hub-coherence-audit-2026-06-16.md`.
+- Az audit kimondja, hogy a hub valos local anchorokra mutat, docs-only/additiv maradt, es a protected-lane fail-closed szemleletet nem gyengitette.
+- A `docs/ai-fejlesztes-veglegesitett-masterterv-2026-03-04.md` most mar a hub mellett ezt az auditot is referenciakent hordozza.
+
 ## 2026-06-03 09:55 CEST - vote-purchase JS null-safe currency fix
 - `impactshop-vote-purchase.js`: `getEffectiveCurrency()` fallback, `preferredCurrency` pre-select, `submitBtn`/`companyToggle` null guard
 - Root cause: `currencySelect` null → TypeError → Adományozom gomb néma. 3 commit: `c073391f`, `abcee270`, `649732f0`

--- a/system-status-snapshot.md
+++ b/system-status-snapshot.md
@@ -1,3 +1,13 @@
+## 2026-06-16T10:20:00+0200 - local governance system plan hub added
+- Uj rovid, repo-helyi governance entrypoint keszult: `docs/impactshop-governance-system-plan-2026-06-16.md`.
+- A dokumentum nem uj policy-t vezet be, hanem a mar ervenyes helyi anchorokat rendezi egybe: `AGENTS.md`, `docs/pr-policy.md`, `PR-EXIT-CHECKLIST.md`, `system-status-snapshot.md`, `notes.md`, `docs/bastion-guard-status.md`.
+- Bekotes megtortent a gyors helyi belpeshez: `AGENTS.md` canonical sources lista, `README.md` start-here blokk es a `docs/ai-fejlesztes-veglegesitett-masterterv-2026-03-04.md` kanonikus tervreferencia.
+
+## 2026-06-16T10:55:00+0200 - governance hub coherence audit added
+- Uj rovid audit rogzitve: `docs/impactshop-governance-hub-coherence-audit-2026-06-16.md`.
+- Az audit explicit modon visszaellenorzi, hogy a helyi governance-hub csak valos anchorokra mutat, docs-only maradt, es nem lazitotta a protected/perimeter szabalyokat.
+- A masterplan referenciaretege frissult, hogy a hub mellett az audit is kanonikus helyi referenciakent elerheto legyen.
+
 ## 2026-06-14T08:20:00+0000 - VB2026 profile-return session carry canonicalized
 - A Sharity source-side profile-return lane kulon account-top es restore-fragment deeplink contractot kapott: `Sharity profil megnyitasa` -> `/profil/?bridge_target=account#impactshop-account-top`, `Ez nem az en fiokom` -> `/profil/?bridge_target=restore#impactshop-restore-title`.
 - A sikeres save/restore mar nem kozvetlen `vb-prod` redirecttel zar, hanem a FactLens `GET /api/vb2026/profile-return/complete` route-jara kuld vissza alairt payloadot, hogy a target host `__Host-factlens_vb_session` cookie-t issue-zon a vegso visszateres elott.


### PR DESCRIPTION
## Summary
- add a short repo-local governance hub/system plan for `impactshop-notes`
- add a narrow coherence audit tied to the new hub
- wire the hub and audit into the local README, AGENTS, masterplan, snapshot, and notes continuity chain

## Scope
- docs-only governance and continuity slice
- no runtime, deploy, or protected-file behavior changes

## Risk
- low
- additive documentation only

## Validation
- `git diff --check`
- `bash scripts/safe-repo-audit.sh --strict --mode push`
- targeted anchor/link presence checks

## Continuity
- updated `notes.md`
- updated `system-status-snapshot.md`
- updated local masterplan reference layer

## Rollback
- revert commit `096f9932` on branch `docs/impactshop-governance-hub-20260616`
- remove the local governance hub/audit references if rollback is needed

## PR Exit Checklist (Required)
- [x] 1. Work was done on dedicated branch/worktree (not `main`)
- [x] 2. Relevant build/tests ran and are green
- [x] 3. `safe-repo-audit.sh --strict --mode push` is green
- [x] 4. `system-status-snapshot.md` updated for module change
- [x] 5. At least one `docs/*.md` updated for module change
- [x] 6. `notes.md` or `conversation-summaries/*` updated (notes-context repos)
- [x] 7. `docs/bastion-guard-status.md` updated when new module file was added
- [x] 8. Deploy guard + smoke checks are logged (if deploy happened)
- [x] 9. Backup/rollback path is recorded
- [x] 10. PR description includes scope, risk, validation, deploy/rollback notes
